### PR TITLE
feat: add racket component

### DIFF
--- a/frontend/components/forms/Input.tsx
+++ b/frontend/components/forms/Input.tsx
@@ -9,7 +9,7 @@ const Input = ({
     <input
       placeholder={placeholder}
       type={type}
-      className="py-2 outline outline-1 outline-blue-100 rounded-md hover:outline-blue-200 text-sm indent-0.5"
+      className="py-2 outline outline-1 outline-blue-100 rounded-md hover:outline-blue-200 text-sm indent-2"
     />
   );
 };

--- a/frontend/components/forms/LoginForms.tsx
+++ b/frontend/components/forms/LoginForms.tsx
@@ -2,9 +2,10 @@ import Input from "components/forms/Input";
 
 const LoginForms = () => {
   return (
-    <form className="flex flex-col gap-1">
+    <form className="flex flex-col gap-2">
       <Input type="email" placeholder="이메일을 입력해주세요" />
       <Input type="password" placeholder="비밀번호를 입력해주세요" />
+      <button onClick={()=>alert('로그인 버튼')}>로그인</button>
     </form>
   );
 };

--- a/frontend/components/rackets/Racket.stories.tsx
+++ b/frontend/components/rackets/Racket.stories.tsx
@@ -4,4 +4,8 @@ export default {
   component: Racket,
 };
 
-export const Default = () => <Racket />;
+export const Default = () => (
+  <div>
+    <Racket />
+  </div>
+);

--- a/frontend/components/rackets/Racket.stories.tsx
+++ b/frontend/components/rackets/Racket.stories.tsx
@@ -1,11 +1,17 @@
+
+import { RacketProps } from "interface/Racket.interface";
 import Racket from "components/rackets/Racket";
 
 export default {
   component: Racket,
 };
 
-export const Default = () => (
-  <div>
-    <Racket />
+export const Default = (args: RacketProps) => (
+  <div className="flex">
+    <Racket {...args} />
   </div>
 );
+
+Default.args={
+  name:'Yonex Nanoray'
+}

--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -1,9 +1,12 @@
-import Image from "next/image";
+import { RacketProps } from "../../interface/Racket.interface";
 
-const Racket = () => {
+const Racket = ({name}:RacketProps) => {
   return (
-    <section className="">
-      <p>라켓 이름</p>
+    <section className="hover:cursor-pointer">
+      <div className="w-40 h-40 bg-red-100 rounded-md max-sm:w-32 max-sm:h-32">
+        <img alt="racket"  src="https://m.woosungsports.com/web/product/big/412_5ff22e3f894ac8106c2773bec3fbe12c.jpg"/>
+      </div>
+      <p>{name}</p>
     </section>
   );
 };

--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -1,4 +1,10 @@
+import Image from "next/image";
+
 const Racket = () => {
-  return <section className="w-12 h-12 bg-blue-200">하이</section>;
+  return (
+    <section className="">
+      <p>라켓 이름</p>
+    </section>
+  );
 };
 export default Racket;

--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -1,13 +1,16 @@
-import { RacketProps } from "../../interface/Racket.interface";
+import { RacketProps } from "interface/Racket.interface";
 
-const Racket = ({name}:RacketProps) => {
-  return (
-    <section className="hover:cursor-pointer">
-      <div className="w-40 h-40 bg-red-100 rounded-md max-sm:w-32 max-sm:h-32">
-        <img alt="racket"  src="https://m.woosungsports.com/web/product/big/412_5ff22e3f894ac8106c2773bec3fbe12c.jpg"/>
-      </div>
-      <p>{name}</p>
-    </section>
-  );
-};
+const Racket = ({ name }: RacketProps) => (
+  <section className=" p-2 rounded-md shadow-lg hover:cursor-pointer  [&>div>img]:hover:scale-125 hover:bg-slate-50 ease-in duration-100 ">
+    <div className="w-40 h-40 overflow-hidden bg-red-100 max-sm:w-32 max-sm:h-32">
+      <img
+        className="overflow-hidden duration-100 ease-in"
+        alt="racket"
+        src="https://m.woosungsports.com/web/product/big/412_5ff22e3f894ac8106c2773bec3fbe12c.jpg"
+      />
+    </div>
+    <p>{name}</p>
+  </section>
+);
+
 export default Racket;

--- a/frontend/interface/Racket.interface.ts
+++ b/frontend/interface/Racket.interface.ts
@@ -1,0 +1,3 @@
+export interface RacketProps{
+  name: string
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -4,14 +4,14 @@ import { Fragment } from "react";
 import Header from "components/common/Header";
 
 const Home: NextPage = () => (
-  <Fragment>
+  <div>
     <Header />
-    <div className="container flex flex-wrap gap-3 ">
+    <div className="container flex flex-wrap gap-3 mx-auto mt-3 ">
       {data.map((name, idx) => (
         <Racket key={idx} name={name} />
       ))}
     </div>
-  </Fragment>
+  </div>
 );
 
 export default Home;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,10 +6,14 @@ import Header from "components/common/Header";
 const Home: NextPage = () => (
   <Fragment>
     <Header />
-    <div className="container flex flex-wrap justify-between">
-      <Racket />
+    <div className="container flex flex-wrap gap-3 ">
+      {data.map((name, idx) => (
+        <Racket key={idx} name={name} />
+      ))}
     </div>
   </Fragment>
 );
 
 export default Home;
+
+const data = Array(10).fill("Yonex nanoray");

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -11,3 +11,6 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+
+


### PR DESCRIPTION
# 설명

라켓 미리보기를 위한 컴포넌트를 작성합니다.

props의 타입을 관리하기 위해, interface만 따로 모아두도록 바꾸었습니다.

# 의문 및 개선할 점
1. img태그를 next/Image 컴포넌트로 바꾸기

nextjs 는 `img` 태그 대신 `Image` 컴포넌트를 사용할 것을 권장하고 있습니다.
그러나, Image 컴포넌트를 사용하게 되면 2가지 문제가 발생합니다.

1. 고정된 width와 height를 사용하게 되면, 라켓 컴포넌트를 반응형으로 만들때 제약이 존재하는 문제

2. 외부 이미지를 사용하기 위해 `next.config.js`에 domain 옵션을 줘도 403 forbidden 에러가 발생하는 문제
