### PR TITLE
feat: add header

### DIFF
--- a/frontend/components/common/Header.stories.tsx
+++ b/frontend/components/common/Header.stories.tsx
@@ -8,10 +8,8 @@ export default {
   },
 };
 
-export const Default = () => {
-  return (
-    <div className="p-0">
-      <Header />
-    </div>
-  );
-};
+export const Default = () => (
+  <div className="p-0">
+    <Header />
+  </div>
+);

--- a/frontend/components/common/Header.stories.tsx
+++ b/frontend/components/common/Header.stories.tsx
@@ -1,0 +1,17 @@
+import Header from "components/common/Header";
+
+export default {
+  title: "common/Header",
+  component: Header,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export const Default = () => {
+  return (
+    <div className="p-0">
+      <Header />
+    </div>
+  );
+};

--- a/frontend/components/common/Header.tsx
+++ b/frontend/components/common/Header.tsx
@@ -1,0 +1,10 @@
+import Link from "next/link";
+
+const Header = () => (
+  <header className="flex items-center justify-end h-12 px-2 bg-black w-vw">
+    <Link href="/login" className="text-white">
+      로그인
+    </Link>
+  </header>
+);
+export default Header;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,11 +1,16 @@
 import type { NextPage } from "next";
 import Racket from "components/rackets/Racket";
+import { Fragment } from "react";
+import Header from "components/common/Header";
 
 const Home: NextPage = () => {
   return (
-    <div className="container flex flex-wrap justify-between">
-      <Racket />
-    </div>
+    <Fragment>
+      <Header />
+      <div className="container flex flex-wrap justify-between">
+        <Racket />
+      </div>
+    </Fragment>
   );
 };
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -3,15 +3,13 @@ import Racket from "components/rackets/Racket";
 import { Fragment } from "react";
 import Header from "components/common/Header";
 
-const Home: NextPage = () => {
-  return (
-    <Fragment>
-      <Header />
-      <div className="container flex flex-wrap justify-between">
-        <Racket />
-      </div>
-    </Fragment>
-  );
-};
+const Home: NextPage = () => (
+  <Fragment>
+    <Header />
+    <div className="container flex flex-wrap justify-between">
+      <Racket />
+    </div>
+  </Fragment>
+);
 
 export default Home;


### PR DESCRIPTION
# 설명
헤더 컴포넌트를 생성합니다.

현재는 결정된 라우팅 설정이 없기 때문에 로그인 링크만 연결되도록 했습니다.

헤더같이 공통으로 사용되는 컴포넌트를 관리하기 위해 `common` 폴더를 추가하였습니다.

# 후속 이슈
- 로고 만들기 + 헤더에 로고 달기
- 로그인 기능 구현 이후, 헤더에 추가되는 여러 항목들 고려
