### PR TITLE
refactor: apply responsive design

### DIFF
--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -1,15 +1,17 @@
 import { RacketProps } from "interface/Racket.interface";
 
 const Racket = ({ name }: RacketProps) => (
-  <section className=" p-2 rounded-md shadow-lg hover:cursor-pointer  [&>div>img]:hover:scale-125 hover:bg-slate-50 ease-in duration-100 ">
-    <div className="w-40 h-40 overflow-hidden bg-red-100 max-sm:w-32 max-sm:h-32">
+  <section className="flex items-center w-full h-32 p-2 mt-1 duration-300 ease-out rounded-md cursor-pointer drop-shadow-sm hover:bg-slate-100 gap-x-2 gap sm:w-80 sm:h-80 sm:block">
+    <div className="justify-center sm:flex">
       <img
-        className="overflow-hidden duration-100 ease-in"
+        className="rounded-md w-28 h-28 sm:w-64 sm:h-64"
         alt="racket"
         src="https://m.woosungsports.com/web/product/big/412_5ff22e3f894ac8106c2773bec3fbe12c.jpg"
       />
     </div>
-    <p>{name}</p>
+    <div className="h-full sm:h-auto">
+      <p>{name}</p>
+    </div>
   </section>
 );
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,12 +1,11 @@
 import type { NextPage } from "next";
 import Racket from "components/rackets/Racket";
-import { Fragment } from "react";
 import Header from "components/common/Header";
 
 const Home: NextPage = () => (
   <div>
     <Header />
-    <div className="container flex flex-wrap gap-3 mx-auto mt-3 ">
+    <div className="mx-auto my-10 max-w-[1280px] flex flex-wrap">
       {data.map((name, idx) => (
         <Racket key={idx} name={name} />
       ))}
@@ -16,4 +15,4 @@ const Home: NextPage = () => (
 
 export default Home;
 
-const data = Array(10).fill("Yonex nanoray");
+const data = Array(11).fill("Yonex nanoray");


### PR DESCRIPTION
# 설명

메인 화면에 보이는 라켓의 컨테이너가 최대 1280px의 넓이를 가지도록 수정하였습니다. 
라켓 컴포넌트의 width가 320px이므로, 최대 넓이에서 4개가 들어갈 수 있습니다.

# 개선점

이전 레이아웃에 적용되어있는 css에 `flex` 속성과  `flex-wrap`을 적용하고 있었는데, flex item이 flex box의 너비 안에 포함되지 못하는 경우 그 여백이 그대로 남아있는 문제가 발생합니다.

`padding` 속성으로 조절해보려 해도, 반응형에서 고정값을 적용하기는 힘들뿐더러, margin과 다르게 `padding:auto` 속성도 존재하지 않기 때문에, 최대 너비를 1280px로 고정하는 방식을 사용하였습니다.

브라우저의 너비가 1280px보다 작아지는 경우는 위와 같은 문제가 다시 발생합니다 😥