### PR TITLE
feat: add racket review component

### DIFF
--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -6,21 +6,23 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => (
   <div className="px-4 max-w-[1200px] mx-auto border-2">
     <h1 className="my-10 text-3xl font-bold">{racketName}</h1>
     <div className="justify-between mx-auto md:flex border-2 border-orange-100">
-      <div className="md:w-1/2 my-4">
+      <section className="md:w-1/2 my-4">
         <img
           alt="racket"
           src="https://m.woosungsports.com/web/product/big/412_5ff22e3f894ac8106c2773bec3fbe12c.jpg"
           className="w-[328px] mx-auto border-2 "
         />
-      </div>
-      <div className="w-[328px] mx-auto md:w-1/2 md:flex md:flex-col md:items-center  ">
+      </section>
+      <section className="w-[328px] mx-auto md:w-1/2 md:flex md:flex-col md:items-center  ">
         <div className="w-[328px] h-[328px] border-2 my-4 flex items-center">
           <Chart />
         </div>
         <EvaluateButton />
-      </div>
+      </section>
     </div>
-    <section>리뷰들</section>
+    <section className=" border-2 border-orange-300 mx-auto">
+      <h1 className="my-10 text-1xl font-bold">리뷰</h1>
+    </section>
   </div>
 );
 

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -1,11 +1,43 @@
 import EvaluateButton from "components/common/EvaluateButton";
 import { RacketDetailProps } from "interface/RacketDetail.interface";
 import Chart from "components/rackets/Chart";
+import Review from "components/rackets/Review";
+
+const testReivew = [
+  {
+    createdAt: "1시간 전",
+    title: "와하하",
+    userId: "test-user",
+    content: "이 라켓은 정말 최고입니다. 와하하 정말 후회하지 않으십니다요",
+    value: 5,
+  },
+  {
+    createdAt: "2시간 전",
+    title: "와하하",
+    userId: "test-user",
+    content: "이 라켓은 정말 최고입니다. 와하하 정말 후회하지 않으십니다요",
+    value: 5,
+  },
+  {
+    createdAt: "3시간 전",
+    title: "와하하",
+    userId: "test-user",
+    content: "이 라켓은 정말 최고입니다. 와하하 정말 후회하지 않으십니다요",
+    value: 5,
+  },
+  {
+    createdAt: "4시간 전",
+    title: "와하하",
+    userId: "test-user",
+    content: "이 라켓은 정말 최고입니다. 와하하 정말 후회하지 않으십니다요",
+    value: 5,
+  },
+];
 
 const RacketDetail = ({ racketName }: RacketDetailProps) => (
-  <div className="px-4 max-w-[1200px] mx-auto border-2">
+  <div className="px-4 max-w-[1200px] mx-auto mb-9">
     <h1 className="my-10 text-3xl font-bold">{racketName}</h1>
-    <div className="justify-between mx-auto md:flex border-2 border-orange-100">
+    <div className="justify-between mx-auto md:flex ">
       <section className="md:w-1/2 my-4">
         <img
           alt="racket"
@@ -20,8 +52,13 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => (
         <EvaluateButton />
       </section>
     </div>
-    <section className=" border-2 border-orange-300 mx-auto">
-      <h1 className="my-10 text-1xl font-bold">리뷰</h1>
+    <section className="mx-auto">
+      <p className="my-4 text-2xl font-bold">리뷰</p>
+      <div className="flex flex-col gap-y-2">
+        {testReivew.map((ele, idx) => (
+          <Review key={idx} {...ele} />
+        ))}
+      </div>
     </section>
   </div>
 );

--- a/frontend/components/rackets/Review.stories.tsx
+++ b/frontend/components/rackets/Review.stories.tsx
@@ -1,0 +1,20 @@
+import Review from "components/rackets/Review";
+import { ReviewProps } from "interface/Review.interface";
+
+export default {
+  component: Review,
+};
+
+export const Default = (args: ReviewProps) => (
+  <div className="max-w-[1200px]">
+    <Review {...args} />
+  </div>
+);
+
+Default.args = {
+  userId: "test-user",
+  content: "정말 최고의 라켓입니다.",
+  value: 4,
+  title: "최고의 라켓",
+  createdAt: "1시간 전",
+};

--- a/frontend/components/rackets/Review.tsx
+++ b/frontend/components/rackets/Review.tsx
@@ -2,7 +2,7 @@ import { ReviewProps } from "interface/Review.interface";
 import ReactStars from "react-rating-stars-component";
 
 const Review = ({ userId, content, value, createdAt, title }: ReviewProps) => (
-  <article className="w-full border-2 rounded-md drop-shadow-sm p-2 hover:cursor-pointer hover:bg-slate-100 duration-300 ease-out ">
+  <article className="w-full border-2 rounded-md drop-shadow-sm p-2 hover:cursor-pointer hover:bg-slate-100 duration-300 ease-out">
     <div className="flex justify-between">
       <ReactStars edit={false} value={value} />
       <p className="text-xs">{createdAt}</p>

--- a/frontend/components/rackets/Review.tsx
+++ b/frontend/components/rackets/Review.tsx
@@ -1,0 +1,15 @@
+import { ReviewProps } from "interface/Review.interface";
+import ReactStars from "react-rating-stars-component";
+
+const Review = ({ userId, content, value, createdAt, title }: ReviewProps) => (
+  <article className="w-full border-2 rounded-md drop-shadow-sm p-2 hover:cursor-pointer hover:bg-slate-100 duration-300 ease-out ">
+    <div className="flex justify-between">
+      <ReactStars edit={false} value={value} />
+      <p className="text-xs">{createdAt}</p>
+    </div>
+    <p className="font-bold">{title}</p>
+    <p className="text-xs">{userId}</p>
+    <p className="text-sm truncate">{content}</p>
+  </article>
+);
+export default Review;

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -1,0 +1,1 @@
+declare module "react-rating-stars-component";

--- a/frontend/interface/Review.interface.ts
+++ b/frontend/interface/Review.interface.ts
@@ -1,0 +1,7 @@
+export interface ReviewProps {
+  createdAt: string;
+  title: string;
+  userId: string;
+  content: string;
+  value: number;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "next": "13.1.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-rating-stars-component": "^2.2.0",
         "recharts": "^2.3.2"
       },
       "devDependencies": {
@@ -21493,6 +21494,11 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/react-rating-stars-component": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-rating-stars-component/-/react-rating-stars-component-2.2.0.tgz",
+      "integrity": "sha512-A3lgLxumfFQQicKQmxacZ91fq/zRaVWlCPnVodJmJV6obvod4/yCotetN9WuyBiUfnKsEFDBo/8B85ocwmL7ng=="
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -42537,6 +42543,11 @@
       "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
       "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
       "dev": true
+    },
+    "react-rating-stars-component": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-rating-stars-component/-/react-rating-stars-component-2.2.0.tgz",
+      "integrity": "sha512-A3lgLxumfFQQicKQmxacZ91fq/zRaVWlCPnVodJmJV6obvod4/yCotetN9WuyBiUfnKsEFDBo/8B85ocwmL7ng=="
     },
     "react-refresh": {
       "version": "0.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "next": "13.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-rating-stars-component": "^2.2.0",
     "recharts": "^2.3.2"
   },
   "devDependencies": {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "typeRoots": ["./@types", "./node_modules/@types"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "frontend"],
   "exclude": ["node_modules"]

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10099,6 +10099,11 @@
   "resolved" "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz"
   "version" "1.1.0"
 
+"react-rating-stars-component@^2.2.0":
+  "integrity" "sha512-A3lgLxumfFQQicKQmxacZ91fq/zRaVWlCPnVodJmJV6obvod4/yCotetN9WuyBiUfnKsEFDBo/8B85ocwmL7ng=="
+  "resolved" "https://registry.npmjs.org/react-rating-stars-component/-/react-rating-stars-component-2.2.0.tgz"
+  "version" "2.2.0"
+
 "react-refresh@^0.11.0", "react-refresh@>=0.10.0 <1.0.0":
   "integrity" "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
   "resolved" "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"


### PR DESCRIPTION
# 설명

라켓 디테일 페이지에 들어갈 리뷰 컴포넌트를 생성합니다.

별점 정보를 표시하기 위해 `react-rating-stars-component` 라이브러리를 사용하였습니다.

# 개선점
`react-rating-stars-component` 라이브러리의 types가 정의되어있지 않아 실행이 되지 않는 문제가 있었습니다. 
일반적인 해결책은 `@types/react-rating-stars-component` 를 같이 설치하는 방법입니다. 

그러나 다음과 같은 이유로 사용되는 타입을 개별적으로 지정해주지 않았습니다.

- @types/react-rating-stars-component 없음
- 다른 별점 라이브러리를 사용할 가능성 존재
- 지금 당장 개발하는데 타입이 없다고 하여, 중요한 문제가 발생하지 않는 것으로 생각됨

따라서 다음과 같이 `index.d.ts`에 선언만 해주는 방식으로 문제를 해결하였습니다.

**index.d.ts**
```typescript
  declare module "react-rating-stars-component";
```



 


