### PR TITLE
feat: add verify token logic

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Body } from '@nestjs/common';
+import { Controller, Get, Body, Param } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { SendVerifyEmailDto } from './dto/sendVerifyEmailDTO';
 
@@ -11,5 +11,14 @@ export class AuthController {
   @Get('/verify-email')
   async sendVerifyMail(@Body() body: SendVerifyEmailDto) {
     await this.authService.sendVerifyEmail(body.email);
+  }
+
+  @Get('/verify-token/:emailToken')
+  async verifyEmailToken(@Param() param: { emailToken: string }) {
+    try {
+      return await this.authService.verifyEmailToken(param.emailToken);
+    } catch (e) {
+      return e;
+    }
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -15,10 +15,6 @@ export class AuthController {
 
   @Get('/verify-token/:emailToken')
   async verifyEmailToken(@Param() param: { emailToken: string }) {
-    try {
-      return await this.authService.verifyEmailToken(param.emailToken);
-    } catch (e) {
-      return e;
-    }
+    return await this.authService.verifyEmailToken(param.emailToken);
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,7 +5,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { AuthRepository } from './auth.repository';
 
 @Module({
-  imports: [JwtModule.register({ secret: 'testSecretKey' })],
+  imports: [JwtModule.register({ secret: process.env.JWT_SECRET_KEY })],
   providers: [AuthService, AuthRepository],
   controllers: [AuthController],
 })

--- a/backend/src/auth/auth.repository.ts
+++ b/backend/src/auth/auth.repository.ts
@@ -12,4 +12,14 @@ export class AuthRepository {
       },
     });
   }
+
+  async getEmailToken(emailToken: string) {
+    const result = await this.prismaService.verification.findUnique({
+      where: {
+        token: emailToken,
+      },
+    });
+
+    return result;
+  }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -42,7 +42,8 @@ export class AuthService {
   async verifyEmailToken(emailToken: string) {
     const result = await this.authRepository.getEmailToken(emailToken);
 
-    if (!result) throw new BadRequestException();
+    if (!result)
+      throw new BadRequestException('Token is not exist in database');
 
     try {
       return this.getEmailFromToken(emailToken);


### PR DESCRIPTION
# 설명
param으로 들어오는 토큰 값이 유효한 토큰인지를 검증하는 API를 개발하였습니다. 논리 흐름은 다음과 같습니다.

1. 우선, `this.authRepository.getEmailToken()` 메소드를 통해 DB에서 해당 토큰 값과 일치하는 값이 있는지 확인합니다.
2. 만약 DB에서 일치하는 값이 존재한다면, 그 객체를 secret key로 verify를 합니다. 
3. 그리고 frontend쪽으로 verify한 내용인 email을 전달합니다.

**의문이 드는 점**
1. http response는 controller layer에서만 이루어져야 하는가? ~(지금은 service layer에서 UnauthorizedException을 날리고 있습니다.)~


2. DB에 값이 존재하지 않는 경우에는 어떠한 reponse를 주어야 하는가? 404 or 400? 
![image](https://user-images.githubusercontent.com/48270642/222117411-063800a1-e32c-4bea-8be4-f5421a2fa706.png)

  **결론**
  - DB에 값이 존재하지 않는 경우 : 400 Bad Request + Tokein is not exist 메시지
  - DB에는 값이 존재하지만, 유효한 토큰이 아닌 경우 : 401 Unauthroized

[비슷한 상황의 글](https://hyeon9mak.github.io/400-bad-request-vs-404-not-found/)을 읽고 참고하였습니다.
