### PR TITLE
feat: seperate header ui

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,4 +1,5 @@
 import "../styles/globals.css";
+import { RecoilRoot } from "recoil";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -9,3 +10,11 @@ export const parameters = {
     },
   },
 };
+
+export const decorators = [
+  (Story) => (
+    <RecoilRoot>
+      <Story />
+    </RecoilRoot>
+  ),
+];

--- a/frontend/components/common/Header.stories.tsx
+++ b/frontend/components/common/Header.stories.tsx
@@ -1,14 +1,24 @@
-import Header from "components/common/Header";
+import { HeaderView } from "components/common/Header";
 
 export default {
-  component: Header,
+  component: HeaderView,
   parameters: {
     layout: "fullscreen",
   },
 };
 
-export const Default = () => (
+export const Default = (args) => (
   <div className="p-0">
-    <Header />
+    <HeaderView {...args} />
   </div>
 );
+
+Default.args = {
+  handleLogout: () => {},
+  loginUser: true,
+};
+
+Default.argTypes = {
+  handleLogout: { table: { disable: true } },
+  loginUser: { control: "boolean" },
+};

--- a/frontend/components/common/Header.tsx
+++ b/frontend/components/common/Header.tsx
@@ -1,10 +1,38 @@
 import Link from "next/link";
+import { useRecoilState } from "recoil";
+import { loginState } from "recoil/atoms/loginState";
 
-const Header = () => (
-  <header className="flex items-center justify-end h-12 px-4 bg-black w-vw">
-    <Link href="/login" className="text-white">
-      로그인
-    </Link>
-  </header>
-);
+const Header = () => {
+  const [loginUser, setLoginUser] = useRecoilState(loginState);
+
+  return (
+    <header className="flex items-center justify-end h-12 px-4 bg-black w-vw gap-x-2">
+      {loginUser ? (
+        <>
+          <Link href="/rackets/yonex" className="text-white">
+            Rackets
+          </Link>
+          <Link href="/emailVerify" className="text-white">
+            프로필
+          </Link>
+          <button className="text-white" onClick={() => setLoginUser(null)}>
+            로그아웃
+          </button>
+        </>
+      ) : (
+        <>
+          <Link href="/rackets/yonex" className="text-white">
+            Rackets
+          </Link>
+          <Link href="/emailVerify" className="text-white">
+            회원가입
+          </Link>
+          <Link href="/login" className="text-white">
+            로그인
+          </Link>
+        </>
+      )}
+    </header>
+  );
+};
 export default Header;

--- a/frontend/components/common/Header.tsx
+++ b/frontend/components/common/Header.tsx
@@ -5,34 +5,38 @@ import { loginState } from "recoil/atoms/loginState";
 const Header = () => {
   const [loginUser, setLoginUser] = useRecoilState(loginState);
 
-  return (
-    <header className="flex items-center justify-end h-12 px-4 bg-black w-vw gap-x-2">
-      {loginUser ? (
-        <>
-          <Link href="/rackets/yonex" className="text-white">
-            Rackets
-          </Link>
-          <Link href="/emailVerify" className="text-white">
-            프로필
-          </Link>
-          <button className="text-white" onClick={() => setLoginUser(null)}>
-            로그아웃
-          </button>
-        </>
-      ) : (
-        <>
-          <Link href="/rackets/yonex" className="text-white">
-            Rackets
-          </Link>
-          <Link href="/emailVerify" className="text-white">
-            회원가입
-          </Link>
-          <Link href="/login" className="text-white">
-            로그인
-          </Link>
-        </>
-      )}
-    </header>
-  );
+  const handleLogout = () => {};
+
+  return <HeaderView handleLogout={handleLogout} loginUser={loginUser} />;
 };
 export default Header;
+
+export const HeaderView = ({ handleLogout, loginUser }) => (
+  <header className="flex items-center justify-end h-12 px-4 bg-black w-vw gap-x-2">
+    {loginUser ? (
+      <>
+        <Link href="/rackets/yonex" className="text-white">
+          Rackets
+        </Link>
+        <Link href="/emailVerify" className="text-white">
+          프로필
+        </Link>
+        <button className="text-white" onClick={handleLogout}>
+          로그아웃
+        </button>
+      </>
+    ) : (
+      <>
+        <Link href="/rackets/yonex" className="text-white">
+          Rackets
+        </Link>
+        <Link href="/emailVerify" className="text-white">
+          회원가입
+        </Link>
+        <Link href="/login" className="text-white">
+          로그인
+        </Link>
+      </>
+    )}
+  </header>
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "react-rating-stars-component": "^2.2.0",
         "react-slick": "^0.29.0",
         "recharts": "^2.3.2",
+        "recoil": "^0.7.7",
         "slick-carousel": "^1.8.1"
       },
       "devDependencies": {
@@ -16235,6 +16236,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "node_modules/handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -21885,6 +21891,25 @@
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
       "dependencies": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/redent": {
@@ -38848,6 +38873,11 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -43023,6 +43053,14 @@
       "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
       "requires": {
         "decimal.js-light": "^2.4.1"
+      }
+    },
+    "recoil": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz",
+      "integrity": "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "redent": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "react-rating-stars-component": "^2.2.0",
     "react-slick": "^0.29.0",
     "recharts": "^2.3.2",
+    "recoil": "^0.7.7",
     "slick-carousel": "^1.8.1"
   },
   "devDependencies": {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,8 +1,15 @@
 import "styles/globals.css";
 import type { AppProps } from "next/app";
+import { RecoilRoot } from "recoil";
+import Header from "components/common/Header";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <RecoilRoot>
+      <Header />
+      <Component {...pageProps} />
+    </RecoilRoot>
+  );
 }
 
 export default MyApp;

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,4 +1,3 @@
-import Header from "components/common/Header";
 import { Html, Main, NextScript, Head } from "next/document";
 
 const Document = () => {
@@ -9,7 +8,6 @@ const Document = () => {
         <meta name="apple-mobile-web-app-capable" content="yes" />
       </Head>
       <body>
-        <Header />
         <Main />
         <div id="modal-root" />
         <NextScript />

--- a/frontend/recoil/atoms/loginState.ts
+++ b/frontend/recoil/atoms/loginState.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const loginState = atom({
+  key: "loginState",
+  default: null,
+});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6806,6 +6806,11 @@
   "resolved" "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   "version" "1.0.4"
 
+"hamt_plus@1.0.2":
+  "integrity" "sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA=="
+  "resolved" "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz"
+  "version" "1.0.2"
+
 "handlebars@^4.7.7":
   "integrity" "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA=="
   "resolved" "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz"
@@ -10243,7 +10248,7 @@
     "prop-types" "^15.6.2"
     "react-lifecycles-compat" "^3.0.4"
 
-"react@^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^15.5.x || ^16.x || ^17.x || ^18.x", "react@^16 || ^17 || ^18", "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.13.1 || ^17.0.0", "react@^16.8.0 || ^17 || ^18", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.4 || ^17.0.0", "react@^16.9.0 || ^17 || ^18", "react@^18.2.0", "react@>= 16", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>= 16.8.6", "react@>=15.0.0", "react@18.2.0":
+"react@^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1", "react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^15.5.x || ^16.x || ^17.x || ^18.x", "react@^16 || ^17 || ^18", "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.13.1 || ^17.0.0", "react@^16.8.0 || ^17 || ^18", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.8.4 || ^17.0.0", "react@^16.9.0 || ^17 || ^18", "react@^18.2.0", "react@>= 16", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0", "react@>= 16.8.6", "react@>=15.0.0", "react@>=16.13.1", "react@18.2.0":
   "integrity" "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="
   "resolved" "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   "version" "18.2.0"
@@ -10456,6 +10461,13 @@
     "recharts-scale" "^0.4.4"
     "reduce-css-calc" "^2.1.8"
     "victory-vendor" "^36.6.8"
+
+"recoil@^0.7.7":
+  "integrity" "sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ=="
+  "resolved" "https://registry.npmjs.org/recoil/-/recoil-0.7.7.tgz"
+  "version" "0.7.7"
+  dependencies:
+    "hamt_plus" "1.0.2"
 
 "redent@^1.0.0":
   "integrity" "sha512-qtW5hKzGQZqKoh6JNSD+4lfitfPKGz42e6QwiRmPM5mmKtR0N41AbJRYu0xJi7nhOJ4WDgRkKvAk6tw4WIwR4g=="


### PR DESCRIPTION
# 설명
- 전역 상태 관리를 위한 recoil 도입 (dev tool도 있어서 기쁨)
- 헤더 컴포넌트에서 view와 logic을 분리합니다. (Header , HeaderView)

###  헤더 컴포넌트를 분리하게 된 배경

기존에 작성된 헤더 컴포넌트는 현재 로그인 여부에 따라 다른 UI를 보여주는 것을 고려하지 않았습니다. (단순히 UI를 위해 작성된 상태)

이제 로그인 api가 붙을 예정이라, FE 쪽에서도 대응이 필요해졌습니다.

로직이 포함된 컴포넌트를 storybook에 작성할 때, 항상 같은 문제에 부딪혔습니다. 
 > **모든 컴포넌트를 pure view component로 분리할 수는 없다.**

![image](https://user-images.githubusercontent.com/48270642/224494637-e19f5f85-c617-4557-a44b-78e59bb56b7e.png)

```javascript
const 자식컴포넌트= () => {
...여러 api들
return <자식뷰컴포넌트{...args}/>
}
```

위와 같이 depth가 한 개인 컴포넌의 경우는 크게 문제가 되지 않습니다.

그러나 다음 같은 경우는?

![image](https://user-images.githubusercontent.com/48270642/224495121-2976dfcf-28c9-4ee4-b72f-7e2ceec0fd90.png)


```javascript
const 부모컴포넌트= () =>{
    return <부모뷰컴포넌트/> 
}

const 부모뷰컴포넌트= () => 
    <>
        <자식컴포넌트/>  // 음... 자식컴포넌트에 들어있는 api를 다 들고 있음
    </>
```

`부모뷰컴포넌트`를 렌더링 하는 순간 결국 `자식컴포넌트`를 렌더링 하기 때문에 기껏 분리해놓은 view가 의미가 없었습니다. (따흐흑)

그렇다고 부모 뷰 컴포넌트에서 자식 뷰 컴포넌트만 따로 렌더링 하는 것도 힘듭니다. (이게 depth가 2개 정도까지는 어떻게든 해볼만 한데... 그 이상이 되면 힘들어...)

이런 문제를 단번에 해결하는 방법이 있는데...! 
최상위 컴포넌트에서 모든 api를 하위 컴포넌트에 전달하는 방식이 있습니다... (눈물)


### 결론

결국 API 호출 부분이 문제가 되는 것이라고 생각하여, api가 호출되는 상황에 따라 다르게 storybook을 작성하기로 결정했습니다.

- 일단 최하단 (트리에서의 리프노드)에 해당하는 컴포넌트는 view / logic 분리
- page단위의 컴포넌트의 경우는 페이지에 접근하자마자 api를 호출하는 경우가 많은데, 이런 경우에는 msw로 모킹 시도.
- 사용자와의 상호작용에 의한 api호출이 있는 경우는... 일단 무시 해야 하려나... (생각중)
