### PR TITLE
feat: add advanced login logic

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   Res,
   Req,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport/dist';
 import { Response } from 'express';
@@ -40,5 +41,22 @@ export class AuthController {
 
     res.cookie('refresh_token', refresh_token);
     return { access_token };
+  }
+
+  @Get('/validate-token')
+  async validateToken(@Req() req) {
+    const { refresh_token } = req.cookies;
+
+    if (!refresh_token) {
+      throw new UnauthorizedException();
+    }
+
+    return this.authService.validateRefreshToken(refresh_token);
+  }
+
+  @Post('/logout')
+  logout(@Res({ passthrough: true }) res: Response) {
+    res.clearCookie('refresh_token');
+    return;
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -76,4 +76,16 @@ export class AuthService {
       refresh_token,
     };
   }
+
+  validateRefreshToken(refreshToken) {
+    const result = this.jwtSerice.verify(refreshToken);
+
+    if (!result) throw new UnauthorizedException();
+
+    const payload = { email: result.email, id: result.id };
+
+    const newAccessToken = this.jwtSerice.sign(payload, { expiresIn: '15m' });
+
+    return newAccessToken;
+  }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,7 @@ import * as cookieParser from 'cookie-parser';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
+  app.enableCors()
 
   const config = new DocumentBuilder()
     .setTitle('Mobae')

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,7 +8,10 @@ import * as cookieParser from 'cookie-parser';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
-  app.enableCors()
+  app.enableCors({
+    origin: true,
+    credentials: true,
+  });
 
   const config = new DocumentBuilder()
     .setTitle('Mobae')

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,5 +1,6 @@
 import "../styles/globals.css";
 import { RecoilRoot } from "recoil";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -13,8 +14,10 @@ export const parameters = {
 
 export const decorators = [
   (Story) => (
-    <RecoilRoot>
-      <Story />
-    </RecoilRoot>
+    <QueryClientProvider client={new QueryClient()}>
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    </QueryClientProvider>
   ),
 ];

--- a/frontend/components/common/CheckLogin.tsx
+++ b/frontend/components/common/CheckLogin.tsx
@@ -1,0 +1,8 @@
+import { useSlientLoginQuery } from "query/auth/login";
+
+const CheckLogin = ({ children }: { children: JSX.Element }) => {
+  useSlientLoginQuery();
+  return children;
+};
+
+export default CheckLogin;

--- a/frontend/components/common/Header.tsx
+++ b/frontend/components/common/Header.tsx
@@ -1,17 +1,29 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { removeBearerToken } from "query/interceptors";
 import { useRecoilState } from "recoil";
 import { loginState } from "recoil/atoms/loginState";
 
 const Header = () => {
   const [loginUser, setLoginUser] = useRecoilState(loginState);
+  const router = useRouter();
 
-  const handleLogout = () => {};
+  const handleLogout = () => {
+    removeBearerToken();
+    setLoginUser(false);
+    router.push("/");
+  };
 
   return <HeaderView handleLogout={handleLogout} loginUser={loginUser} />;
 };
 export default Header;
 
-export const HeaderView = ({ handleLogout, loginUser }) => (
+interface HeaderViewProps {
+  handleLogout: () => void;
+  loginUser: boolean;
+}
+
+export const HeaderView = ({ handleLogout, loginUser }: HeaderViewProps) => (
   <header className="flex items-center justify-end h-12 px-4 bg-black w-vw gap-x-2">
     {loginUser ? (
       <>

--- a/frontend/components/common/Header.tsx
+++ b/frontend/components/common/Header.tsx
@@ -1,20 +1,15 @@
 import Link from "next/link";
-import { useRouter } from "next/router";
-import { removeBearerToken } from "query/interceptors";
-import { useRecoilState } from "recoil";
-import { loginState } from "recoil/atoms/loginState";
+import { useLogoutMutation } from "query/auth/logout";
+import { useRecoilValue } from "recoil";
+import { accessTokenState } from "recoil/atoms/accessToken";
 
 const Header = () => {
-  const [loginUser, setLoginUser] = useRecoilState(loginState);
-  const router = useRouter();
+  const loginUser = useRecoilValue(accessTokenState);
+  const { mutate: handleLogout } = useLogoutMutation();
 
-  const handleLogout = () => {
-    removeBearerToken();
-    setLoginUser(false);
-    router.push("/");
-  };
+  const isLogin = loginUser !== "NO_LOGIN" && loginUser !== "PENDING";
 
-  return <HeaderView handleLogout={handleLogout} loginUser={loginUser} />;
+  return <HeaderView handleLogout={handleLogout} loginUser={isLogin} />;
 };
 export default Header;
 

--- a/frontend/components/forms/Input.tsx
+++ b/frontend/components/forms/Input.tsx
@@ -1,20 +1,16 @@
+import { ForwardedRef, forwardRef } from "react";
 import { InputProps } from "interface/Input.interface";
 
-const Input = ({
-  type = "text",
-  placeholder,
-  isRequired = false,
-  disabled = false,
-}: InputProps) => {
-  return (
+const Input = forwardRef(
+  (props: InputProps, ref: ForwardedRef<HTMLInputElement>) => (
     <input
-      placeholder={placeholder}
-      type={type}
+      {...props}
+      ref={ref}
       className="w-full py-2 text-sm rounded-md outline outline-1 outline-blue-100 hover:outline-blue-200 indent-2"
-      disabled={disabled}
-      required={isRequired}
     />
-  );
-};
+  ),
+);
+
+Input.displayName = "Input";
 
 export default Input;

--- a/frontend/components/forms/LoginForms.tsx
+++ b/frontend/components/forms/LoginForms.tsx
@@ -1,21 +1,39 @@
+import { useForm } from "react-hook-form";
 import Input from "components/forms/Input";
 import Link from "next/link";
+import { useLoginMutation } from "query/auth/login";
 
 const LoginForms = () => {
+  const { register, handleSubmit } = useForm();
+  const { mutate: loginMutate } = useLoginMutation();
+
   return (
     <div className="flex flex-col items-center justify-center w-screen h-full ">
       <div>로고</div>
       <form
         className="w-[328px] flex flex-col gap-2 "
-        onSubmit={(e) => e.preventDefault()}
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit((data) =>
+            loginMutate({ email: data.email, password: data.password }),
+          )();
+        }}
       >
-        <Input type="email" placeholder="이메일을 입력해주세요" isRequired />
+        <Input
+          type="email"
+          placeholder="이메일을 입력해주세요"
+          {...register("email", { required: true })}
+        />
         <Input
           type="password"
           placeholder="비밀번호를 입력해주세요"
-          isRequired
+          minLength={8}
+          {...register("password", { required: true })}
         />
-        <button className="w-full h-8 bg-blue-300 rounded-md hover:cursor-pointer hover:text-white max-w-[328px] duration-300 ease-out hover:bg-blue-500">
+        <button
+          type="submit"
+          className="w-full h-8 bg-blue-300 rounded-md hover:cursor-pointer hover:text-white max-w-[328px] duration-300 ease-out hover:bg-blue-500"
+        >
           로그인
         </button>
 

--- a/frontend/interface/Input.interface.ts
+++ b/frontend/interface/Input.interface.ts
@@ -1,6 +1,2 @@
-export interface InputProps {
-  type: string;
-  placeholder?: string;
-  isRequired?: boolean;
-  disabled?: boolean;
-}
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@headlessui/react": "^1.7.11",
         "@heroicons/react": "^2.0.16",
+        "@tanstack/react-query": "^4.26.1",
         "@types/react-datepicker": "^4.8.0",
+        "axios": "^1.3.4",
         "date-fns": "^2.29.3",
         "lottie-react": "^2.4.0",
         "next": "13.1.1",
@@ -8985,6 +8987,41 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz",
+      "integrity": "sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.26.1.tgz",
+      "integrity": "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==",
+      "dependencies": {
+        "@tanstack/query-core": "4.26.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "8.19.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.1.tgz",
@@ -10801,8 +10838,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -10879,6 +10915,29 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -12399,7 +12458,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -13634,7 +13692,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -15562,6 +15619,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -19187,7 +19263,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -19196,7 +19271,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -21281,6 +21355,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -25509,6 +25588,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {
@@ -33124,6 +33211,20 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tanstack/query-core": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz",
+      "integrity": "sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.26.1.tgz",
+      "integrity": "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==",
+      "requires": {
+        "@tanstack/query-core": "4.26.1",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "@testing-library/dom": {
       "version": "8.19.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.1.tgz",
@@ -34670,8 +34771,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -34710,6 +34810,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.2.tgz",
       "integrity": "sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==",
       "dev": true
+    },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -35868,7 +35990,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -36831,8 +36952,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -38373,6 +38493,11 @@
           "dev": true
         }
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -41050,14 +41175,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -42596,6 +42719,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",
@@ -45830,6 +45958,12 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@headlessui/react": "^1.7.11",
         "@heroicons/react": "^2.0.16",
         "@tanstack/react-query": "^4.26.1",
+        "@tanstack/react-query-devtools": "^4.26.1",
         "@types/react-datepicker": "^4.8.0",
         "axios": "^1.3.4",
         "date-fns": "^2.29.3",
@@ -8988,6 +8989,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.7.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz",
+      "integrity": "sha512-2AMpRiA6QivHOUiBpQAVxjiHAA68Ei23ZUMNaRJrN6omWiSFLoYrxGcT6BXtuzp0Jw4h6HZCmGGIM/gbwebO2A==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "4.26.1",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz",
@@ -9021,6 +9037,25 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.26.1.tgz",
+      "integrity": "sha512-ts2mA+fyFYFRi3Cee4xBk8Fx6waSFOM+yCkFqwJfGQRGjjTIMYMZPJv4wkv7vy12IVi1SYhL8au22LRKlXS1Zg==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.26.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -12679,6 +12714,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz",
+      "integrity": "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/copy-concurrently": {
       "version": "1.0.5",
@@ -17665,6 +17714,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz",
+      "integrity": "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/is-whitespace-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
@@ -22396,6 +22456,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -24449,6 +24514,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.2.tgz",
+      "integrity": "sha512-ugvUo9/WmvWOjstornQhsN/sR9mnGtWGYeTxFuqLb4AiT4QdUavjGFRALCPKWWnAiUJ4HTpytj5e0t5HoMRkXg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -33227,6 +33303,14 @@
         "defer-to-connect": "^2.0.0"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.7.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz",
+      "integrity": "sha512-2AMpRiA6QivHOUiBpQAVxjiHAA68Ei23ZUMNaRJrN6omWiSFLoYrxGcT6BXtuzp0Jw4h6HZCmGGIM/gbwebO2A==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
     "@tanstack/query-core": {
       "version": "4.26.1",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz",
@@ -33238,6 +33322,16 @@
       "integrity": "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==",
       "requires": {
         "@tanstack/query-core": "4.26.1",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.26.1.tgz",
+      "integrity": "sha512-ts2mA+fyFYFRi3Cee4xBk8Fx6waSFOM+yCkFqwJfGQRGjjTIMYMZPJv4wkv7vy12IVi1SYhL8au22LRKlXS1Zg==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
         "use-sync-external-store": "^1.2.0"
       }
     },
@@ -36189,6 +36283,14 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "copy-anything": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz",
+      "integrity": "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==",
+      "requires": {
+        "is-what": "^4.1.8"
+      }
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -39940,6 +40042,11 @@
         "get-intrinsic": "^1.1.1"
       }
     },
+    "is-what": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz",
+      "integrity": "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA=="
+    },
     "is-whitespace-character": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
@@ -43516,6 +43623,11 @@
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -45123,6 +45235,14 @@
       "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
       "requires": {
         "client-only": "0.0.1"
+      }
+    },
+    "superjson": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.2.tgz",
+      "integrity": "sha512-ugvUo9/WmvWOjstornQhsN/sR9mnGtWGYeTxFuqLb4AiT4QdUavjGFRALCPKWWnAiUJ4HTpytj5e0t5HoMRkXg==",
+      "requires": {
+        "copy-anything": "^3.0.2"
       }
     },
     "supports-color": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react": "18.2.0",
         "react-datepicker": "^4.10.0",
         "react-dom": "18.2.0",
+        "react-hook-form": "^7.43.5",
         "react-rating-stars-component": "^2.2.0",
         "react-slick": "^0.29.0",
         "recharts": "^2.3.2",
@@ -21684,6 +21685,21 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
+    "node_modules/react-hook-form": {
+      "version": "7.43.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.5.tgz",
+      "integrity": "sha512-YcaXhuFHoOPipu5pC7ckxrLrialiOcU91pKu8P+isAcXZyMgByUK9PkI9j5fENO4+6XU5PwWXRGMIFlk9u9UBQ==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -42971,6 +42987,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+    },
+    "react-hook-form": {
+      "version": "7.43.5",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.5.tgz",
+      "integrity": "sha512-YcaXhuFHoOPipu5pC7ckxrLrialiOcU91pKu8P+isAcXZyMgByUK9PkI9j5fENO4+6XU5PwWXRGMIFlk9u9UBQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,9 @@
   "dependencies": {
     "@headlessui/react": "^1.7.11",
     "@heroicons/react": "^2.0.16",
+    "@tanstack/react-query": "^4.26.1",
     "@types/react-datepicker": "^4.8.0",
+    "axios": "^1.3.4",
     "date-fns": "^2.29.3",
     "lottie-react": "^2.4.0",
     "next": "13.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "react": "18.2.0",
     "react-datepicker": "^4.10.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.43.5",
     "react-rating-stars-component": "^2.2.0",
     "react-slick": "^0.29.0",
     "recharts": "^2.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@headlessui/react": "^1.7.11",
     "@heroicons/react": "^2.0.16",
     "@tanstack/react-query": "^4.26.1",
+    "@tanstack/react-query-devtools": "^4.26.1",
     "@types/react-datepicker": "^4.8.0",
     "axios": "^1.3.4",
     "date-fns": "^2.29.3",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,16 +3,29 @@ import type { AppProps } from "next/app";
 import { RecoilRoot } from "recoil";
 import Header from "components/common/Header";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import CheckLogin from "components/common/CheckLogin";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
-        <Header />
-        <Component {...pageProps} />
+        <CheckLogin>
+          <>
+            <Header />
+            <Component {...pageProps} />
+          </>
+        </CheckLogin>
       </RecoilRoot>
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );
 }

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,13 +2,18 @@ import "styles/globals.css";
 import type { AppProps } from "next/app";
 import { RecoilRoot } from "recoil";
 import Header from "components/common/Header";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <RecoilRoot>
-      <Header />
-      <Component {...pageProps} />
-    </RecoilRoot>
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <Header />
+        <Component {...pageProps} />
+      </RecoilRoot>
+    </QueryClientProvider>
   );
 }
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -4,14 +4,21 @@ import CheckMounted from "components/common/CheckMounted";
 import MainGreetingCarousel from "components/carousels/MainGreetingCarousel";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import axios from "query/axios";
 
 const Home: NextPage = () => {
+  const e = async () => {
+    const { data } = await axios.get("/auth/validate-token");
+    console.log(data);
+  };
+
   return (
     <div className="flex flex-col gap-y-5 border-red-900 max-w-[1200px] h-screen mx-auto p-4 ">
       <MainGreetingCarousel />
       <CheckMounted>
         <MainRacketCarousel />
       </CheckMounted>
+      <button onClick={async () => await e()}>테스트~</button>
     </div>
   );
 };

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,4 +1,3 @@
-import Header from "components/common/Header";
 import LoginForms from "components/forms/LoginForms";
 import { NextPage } from "next";
 

--- a/frontend/query/auth/login.ts
+++ b/frontend/query/auth/login.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query";
+import axios from "query/axios";
+
+interface LoginFormData {
+  email: string;
+  password: string;
+}
+
+const login = async (loginFormData: LoginFormData) => {
+  const { data } = await axios.post("/auth/login", {
+    ...loginFormData,
+  });
+
+  return data;
+};
+
+export const useLoginMutation = () =>
+  useMutation((loginFormData: LoginFormData) => login(loginFormData));

--- a/frontend/query/auth/login.ts
+++ b/frontend/query/auth/login.ts
@@ -1,5 +1,10 @@
 import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { useRouter } from "next/router";
 import axios from "query/axios";
+import { setBearerToken } from "query/interceptors";
+import { useSetRecoilState } from "recoil";
+import { loginState } from "recoil/atoms/loginState";
 
 interface LoginFormData {
   email: string;
@@ -14,5 +19,22 @@ const login = async (loginFormData: LoginFormData) => {
   return data;
 };
 
-export const useLoginMutation = () =>
-  useMutation((loginFormData: LoginFormData) => login(loginFormData));
+export const useLoginMutation = () => {
+  const router = useRouter();
+  const setLoginState = useSetRecoilState(loginState);
+
+  return useMutation((loginFormData: LoginFormData) => login(loginFormData), {
+    onSuccess: (data) => {
+      setBearerToken(data.access_token);
+      setLoginState(true);
+      router.push("/");
+    },
+    onError: (error: AxiosError) => {
+      if (error.response?.status === 500) {
+        alert("서버에 문제가 발생하였습니다.");
+      } else {
+        alert("로그인에 실패하였습니다.");
+      }
+    },
+  });
+};

--- a/frontend/query/auth/logout.ts
+++ b/frontend/query/auth/logout.ts
@@ -1,0 +1,25 @@
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import axios from "query/axios";
+import { removeBearerToken } from "query/interceptors";
+import { useSetRecoilState } from "recoil";
+import { accessTokenState, LoginState } from "recoil/atoms/accessToken";
+
+const logout = async () => {
+  const { data } = await axios.post("/auth/logout");
+  return data;
+};
+
+export const useLogoutMutation = () => {
+  const router = useRouter();
+  const setAccessTokenState = useSetRecoilState(accessTokenState);
+
+  return useMutation(() => logout(), {
+    onSuccess: () => {
+      removeBearerToken();
+      setAccessTokenState(LoginState["NO_LOGIN"]);
+      router.push("/");
+    },
+    onError: () => {},
+  });
+};

--- a/frontend/query/axios.ts
+++ b/frontend/query/axios.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = "localhost:8000";
+const baseURL = "http://localhost:8000";
 
 export default axios.create({
   baseURL,

--- a/frontend/query/axios.ts
+++ b/frontend/query/axios.ts
@@ -4,4 +4,5 @@ const baseURL = "http://localhost:8000";
 
 export default axios.create({
   baseURL,
+  withCredentials: true,
 });

--- a/frontend/query/axios.ts
+++ b/frontend/query/axios.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const baseURL = "localhost:8000";
+
+export default axios.create({
+  baseURL,
+});

--- a/frontend/query/interceptors.ts
+++ b/frontend/query/interceptors.ts
@@ -1,0 +1,12 @@
+import axios from "query/axios";
+
+export const setBearerToken = (token: string) => {
+  axios.interceptors.request.use((config) => {
+    config.headers.Authorization = `Bearer ${token}`;
+    return config;
+  });
+};
+
+export const removeBearerToken = () => {
+  axios.interceptors.request.clear();
+};

--- a/frontend/query/queryKeys.ts
+++ b/frontend/query/queryKeys.ts
@@ -1,0 +1,5 @@
+export const queryKeys = Object.freeze({
+  auth: {
+    tokenState: ["auth", "tokenState"],
+  },
+});

--- a/frontend/recoil/atoms/accessToken.ts
+++ b/frontend/recoil/atoms/accessToken.ts
@@ -1,0 +1,11 @@
+import { atom } from "recoil";
+
+export enum LoginState {
+  PENDING = "PENDING",
+  NO_LOGIN = "NO_LOGIN",
+}
+
+export const accessTokenState = atom<string>({
+  key: "accessTokenState",
+  default: LoginState["PENDING"],
+});

--- a/frontend/recoil/atoms/loginState.ts
+++ b/frontend/recoil/atoms/loginState.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 
-export const loginState = atom({
+export const loginState = atom<boolean>({
   key: "loginState",
-  default: null,
+  default: false,
 });

--- a/frontend/recoil/atoms/loginState.ts
+++ b/frontend/recoil/atoms/loginState.ts
@@ -1,6 +1,0 @@
-import { atom } from "recoil";
-
-export const loginState = atom<boolean>({
-  key: "loginState",
-  default: false,
-});

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2529,12 +2529,28 @@
   dependencies:
     "defer-to-connect" "^2.0.0"
 
+"@tanstack/match-sorter-utils@^8.7.0":
+  "integrity" "sha512-2AMpRiA6QivHOUiBpQAVxjiHAA68Ei23ZUMNaRJrN6omWiSFLoYrxGcT6BXtuzp0Jw4h6HZCmGGIM/gbwebO2A=="
+  "resolved" "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.6.tgz"
+  "version" "8.7.6"
+  dependencies:
+    "remove-accents" "0.4.2"
+
 "@tanstack/query-core@4.26.1":
   "integrity" "sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg=="
   "resolved" "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz"
   "version" "4.26.1"
 
-"@tanstack/react-query@^4.26.1":
+"@tanstack/react-query-devtools@^4.26.1":
+  "integrity" "sha512-ts2mA+fyFYFRi3Cee4xBk8Fx6waSFOM+yCkFqwJfGQRGjjTIMYMZPJv4wkv7vy12IVi1SYhL8au22LRKlXS1Zg=="
+  "resolved" "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.26.1.tgz"
+  "version" "4.26.1"
+  dependencies:
+    "@tanstack/match-sorter-utils" "^8.7.0"
+    "superjson" "^1.10.0"
+    "use-sync-external-store" "^1.2.0"
+
+"@tanstack/react-query@^4.26.1", "@tanstack/react-query@4.26.1":
   "integrity" "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg=="
   "resolved" "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.26.1.tgz"
   "version" "4.26.1"
@@ -4840,6 +4856,13 @@
   "integrity" "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
   "resolved" "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   "version" "0.5.0"
+
+"copy-anything@^3.0.2":
+  "integrity" "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw=="
+  "resolved" "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz"
+  "version" "3.0.3"
+  dependencies:
+    "is-what" "^4.1.8"
 
 "copy-concurrently@^1.0.0":
   "integrity" "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A=="
@@ -7693,6 +7716,11 @@
   dependencies:
     "call-bind" "^1.0.2"
     "get-intrinsic" "^1.1.1"
+
+"is-what@^4.1.8":
+  "integrity" "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA=="
+  "resolved" "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz"
+  "version" "4.1.8"
 
 "is-whitespace-character@^1.0.0":
   "integrity" "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
@@ -10679,6 +10707,11 @@
   dependencies:
     "mdast-squeeze-paragraphs" "^4.0.0"
 
+"remove-accents@0.4.2":
+  "integrity" "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+  "resolved" "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz"
+  "version" "0.4.2"
+
 "remove-trailing-separator@^1.0.1":
   "integrity" "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="
   "resolved" "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
@@ -11717,6 +11750,13 @@
   "version" "5.1.1"
   dependencies:
     "client-only" "0.0.1"
+
+"superjson@^1.10.0":
+  "integrity" "sha512-ugvUo9/WmvWOjstornQhsN/sR9mnGtWGYeTxFuqLb4AiT4QdUavjGFRALCPKWWnAiUJ4HTpytj5e0t5HoMRkXg=="
+  "resolved" "https://registry.npmjs.org/superjson/-/superjson-1.12.2.tgz"
+  "version" "1.12.2"
+  dependencies:
+    "copy-anything" "^3.0.2"
 
 "supports-color@^5.3.0":
   "integrity" "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10196,6 +10196,11 @@
   "resolved" "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz"
   "version" "3.2.0"
 
+"react-hook-form@^7.43.5":
+  "integrity" "sha512-YcaXhuFHoOPipu5pC7ckxrLrialiOcU91pKu8P+isAcXZyMgByUK9PkI9j5fENO4+6XU5PwWXRGMIFlk9u9UBQ=="
+  "resolved" "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.5.tgz"
+  "version" "7.43.5"
+
 "react-inspector@^5.1.0":
   "integrity" "sha512-GURDaYzoLbW8pMGXwYPDBIv6nqei4kK7LPRZ9q9HCZF54wqXz/dnylBp/kfE9XmekBhHvLDdcYeyIwSrvtOiWg=="
   "resolved" "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.1.tgz"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2529,6 +2529,19 @@
   dependencies:
     "defer-to-connect" "^2.0.0"
 
+"@tanstack/query-core@4.26.1":
+  "integrity" "sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg=="
+  "resolved" "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.26.1.tgz"
+  "version" "4.26.1"
+
+"@tanstack/react-query@^4.26.1":
+  "integrity" "sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg=="
+  "resolved" "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.26.1.tgz"
+  "version" "4.26.1"
+  dependencies:
+    "@tanstack/query-core" "4.26.1"
+    "use-sync-external-store" "^1.2.0"
+
 "@testing-library/dom@^8.3.0", "@testing-library/dom@>=7.21.4":
   "integrity" "sha512-P6iIPyYQ+qH8CvGauAqanhVnjrnRe0IZFSYCeGkSRW9q3u8bdVn2NPI+lasFyVsEQn1J/IFmp5Aax41+dAP9wg=="
   "resolved" "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.1.tgz"
@@ -3829,6 +3842,15 @@
   "integrity" "sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg=="
   "resolved" "https://registry.npmjs.org/axe-core/-/axe-core-4.6.2.tgz"
   "version" "4.6.2"
+
+"axios@^1.3.4":
+  "integrity" "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ=="
+  "resolved" "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz"
+  "version" "1.3.4"
+  dependencies:
+    "follow-redirects" "^1.15.0"
+    "form-data" "^4.0.0"
+    "proxy-from-env" "^1.1.0"
 
 "axobject-query@^2.2.0":
   "integrity" "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA=="
@@ -6368,6 +6390,11 @@
   dependencies:
     "tslib" "^1.9.3"
 
+"follow-redirects@^1.15.0":
+  "integrity" "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+  "resolved" "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
+  "version" "1.15.2"
+
 "for-each@^0.3.3":
   "integrity" "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw=="
   "resolved" "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
@@ -6424,6 +6451,15 @@
   "integrity" "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg=="
   "resolved" "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz"
   "version" "3.0.1"
+  dependencies:
+    "asynckit" "^0.4.0"
+    "combined-stream" "^1.0.8"
+    "mime-types" "^2.1.12"
+
+"form-data@^4.0.0":
+  "integrity" "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww=="
+  "resolved" "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
+  "version" "4.0.0"
   dependencies:
     "asynckit" "^0.4.0"
     "combined-stream" "^1.0.8"
@@ -9966,6 +10002,11 @@
     "forwarded" "0.2.0"
     "ipaddr.js" "1.9.1"
 
+"proxy-from-env@^1.1.0":
+  "integrity" "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+  "resolved" "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
+  "version" "1.1.0"
+
 "prr@~1.0.1":
   "integrity" "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
   "resolved" "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
@@ -12344,6 +12385,11 @@
   dependencies:
     "punycode" "1.3.2"
     "querystring" "0.2.0"
+
+"use-sync-external-store@^1.2.0":
+  "integrity" "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
+  "resolved" "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz"
+  "version" "1.2.0"
 
 "use@^3.1.0":
   "integrity" "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="


### PR DESCRIPTION
# 설명
프론트엔드에서 필요한 로그인 로직을 작성합니다.

- [x] 일반적인 로그인 flow
- [x] 새로고침 및 새롭게 마운트 되는 경우 자동으로 로그인 하는 flow
- [x] 로그아웃 flow

### 현재 로그인 전략
**일반적인 로그인 flow**
- 로그인에 성공하면 서버에서 access_token을 리턴합니다.
- refresh_token은 쿠키🍪 에 저장됩니다. (httpOnly 옵션과 같이...)
- axios interceptor를 통해 `Authorization` 헤더에 access_token 값을 넣습니다. 
- 로그인 상태 여부를 판별하기 위해 token atom에 access_token의 값을 넣습니다.

**새로 화면이 마운트 되는 경우 flow**
- access_token이 없는 경우 cookie에 있는 refresh_token을 서버에서 검증합니다. 유효한 경우는 access_token을 재발급 해줍니다.
- refresh_token이 유효하지 않은 경우 401 Unauthrized Error를 throw하며, 로그인 페이지로 넘어갑니다.

**로그아웃 flow**
- 발급받은 access_token과 refresh_token을 모두 삭제합니다.
- cookie는 서버에서 접근 가능하기 때문에, logout api를 호출합니다.


### 자동 로그인 플로우
![image](https://user-images.githubusercontent.com/48270642/225591221-9ba1df64-bb04-4297-ba0b-b82c1a77a794.png)



### 개선점
- UX 관련
  - silentLogin Query를 호출해서, 그 결과를 알기 전까지는 로그인 하지 않은 경우의 UI가 나타납니다. 짧은 순간이긴 하지만, 유저 입장에서 혼란을 불러올 수 있음
  - 서버사이드에서 값을 호출 하고, 그 값을 렌더링 하는 방법이 있는지 확인

- unauthorized 값을 받더라도, 반드시 login page로 보내야하는 것은 아니다.
  - 실제로 로그인은 되어있지만, 권한이 없는 경우도 존재하기 때문


### 궁금한 점
- 현재 accessToken atom을 정의하는 값을 enum객체로 관리하고 있는데, enum은 tree-shaking이 안된다는 글을 봤다. 다른 방법으로 Union type을 제시하고 있는데, 고려해볼 것