### PR TITLE
refactor: connect racket list api in carousel

### DIFF
--- a/frontend/components/carousels/MainRacketCarousel.tsx
+++ b/frontend/components/carousels/MainRacketCarousel.tsx
@@ -1,9 +1,13 @@
 import Racket from "components/rackets/Racket";
+import { IRacket } from "interface/Racket.interface";
+import { useRacketListQuery } from "query/rackets/rackets";
 import { useEffect, useState } from "react";
 import Slider, { Settings } from "react-slick";
 import { debounce } from "utils/debounce";
 
 const MainRacketCarousel = () => {
+  const { data } = useRacketListQuery();
+
   const [clientWidth, setClientWidth] = useState(
     document.documentElement.clientWidth,
   );
@@ -11,19 +15,28 @@ const MainRacketCarousel = () => {
   const handleResize = () =>
     setClientWidth(document.documentElement.clientWidth);
 
-  const isMobile = () => clientWidth < 768;
-
   useEffect(() => {
     addEventListener("resize", debounce(handleResize));
 
     return removeEventListener("resize", () => {});
   }, []);
 
+  return <MainRacketCarouselView clientWidth={clientWidth} rackets={data} />;
+};
+export default MainRacketCarousel;
+
+const MainRacketCarouselView = ({
+  clientWidth,
+  rackets,
+}: {
+  clientWidth: number;
+  rackets: IRacket[];
+}) => {
   const sliderOptions: Settings = {
     arrows: false,
     slidesToShow: 3,
-    vertical: isMobile(),
-    verticalSwiping: isMobile(),
+    vertical: clientWidth < 768,
+    verticalSwiping: clientWidth < 768,
     autoplay: true,
     autoplaySpeed: 2000,
   };
@@ -33,12 +46,10 @@ const MainRacketCarousel = () => {
       <p className="text-2xl font-bold">브랜드 별 라켓을 찾아보세요</p>
       <p className="text-xl font-bold">YONEX</p>
       <Slider {...sliderOptions}>
-        <Racket name="나노레이 700" racketId={1} />
-        <Racket name="나노레이 700" racketId={1} />
-        <Racket name="나노레이 700" racketId={1} />
-        <Racket name="나노레이 700" racketId={1} />
+        {rackets.rackets.map((racket) => (
+          <Racket key={racket.id} name={racket.name} racketId={racket.id} />
+        ))}
       </Slider>
     </section>
   );
 };
-export default MainRacketCarousel;

--- a/frontend/interface/Racket.interface.ts
+++ b/frontend/interface/Racket.interface.ts
@@ -5,7 +5,7 @@ export interface RacketProps {
 
 export interface RacketResponse {
   count: number;
-  rackets: Racket[];
+  rackets: IRacket[];
 }
 
 export interface RacketListViewProps {
@@ -14,11 +14,11 @@ export interface RacketListViewProps {
   curPage: number;
 }
 
-interface Racket {
+export interface IRacket {
   id: number;
   brand: string;
   name: string;
-  rating: 5;
+  rating: number;
   price: number;
   image: string | null;
   shaft: string;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,10 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  ignoreDuringBuilds: true,
-  typescript: {
-    ignoreBuildErrors: true,
-  },
+
 };
 
 module.exports = nextConfig;

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -5,8 +5,6 @@ import Header from "components/common/Header";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import CheckLogin from "components/common/CheckLogin";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { ErrorBoundary } from "react-error-boundary";
-import { S3 } from "@aws-sdk/client-s3";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -23,9 +21,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <CheckLogin>
           <>
             <Header />
-            <ErrorBoundary fallback={<div>정말 되는거니</div>}>
-              <Component {...pageProps} />
-            </ErrorBoundary>
+            <Component {...pageProps} />
           </>
         </CheckLogin>
       </RecoilRoot>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,17 +1,23 @@
 import type { NextPage } from "next";
-import MainRacketCarousel from "components/carousels/MainRacketCarousel";
-import CheckMounted from "components/common/CheckMounted";
 import MainGreetingCarousel from "components/carousels/MainGreetingCarousel";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import dynamic from "next/dynamic";
+import Spinner from "components/common/Spinner";
+
+const MainRacketCarousel = dynamic(
+  () => import("components/carousels/MainRacketCarousel"),
+  {
+    loading: () => <Spinner />,
+    ssr: false,
+  },
+);
 
 const Home: NextPage = () => {
   return (
     <div className="flex flex-col gap-y-5 border-red-900 max-w-[1200px] h-screen mx-auto p-4 ">
       <MainGreetingCarousel />
-      <CheckMounted>
-        <MainRacketCarousel />
-      </CheckMounted>
+      <MainRacketCarousel />
     </div>
   );
 };


### PR DESCRIPTION
## 설명

- 메인 화면의 케러셀에 하드코딩되어있는 데이터를 제거하고 api를 호출하여 데이터를 불러옵니다.

## 관련 이슈

Fix #72 

## 변경사항
- 이전 PR 에서 테스트를 위해 `ignore` 했던 옵션들을 원 상태로 복구합니다.
- `MainRacketCarouselView` 의 prop으로 들어갈 interface를 위해 Racket의 인터페이스 네이밍을 변경합니다.
   - `Racket `-> `IRacket`
   - [Google Typescript Style Guide](https://google.github.io/styleguide/tsguide.html)의 내용에 따르면 ,interface를 명시하는 네이밍을 지양하라고 합니다. (IRacket, RacketInterface 등...) 더 적절한 네이밍이 있는지 조사할 필요가 있습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/48270642/229361482-d3ab801e-d8e4-410c-b96d-3c2ca0657165.png)

