### PR TITLE
feat: add basic charts

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { MailerModule } from '@nestjs-modules/mailer';
 import { EjsAdapter } from '@nestjs-modules/mailer/dist/adapters/ejs.adapter';
 import { AuthModule } from 'auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
+import { StatisticsModule } from 'statistics/statistics.module';
 
 @Module({
   imports: [
@@ -45,6 +46,7 @@ import { ConfigModule } from '@nestjs/config';
       }),
     }),
     AuthModule,
+    StatisticsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/rackets/rackets.controller.ts
+++ b/backend/src/rackets/rackets.controller.ts
@@ -22,4 +22,9 @@ export class RacketsController {
   ) {
     return this.racketsService.getRacketList(brand, page);
   }
+
+  @Get('/:racketId/detail')
+  async getRacket(@Param('racketId', ParseIntPipe) racketId: number) {
+    return this.racketsService.getRacket(racketId);
+  }
 }

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -52,11 +52,17 @@ export class ReviewsController {
   @Patch('/:reviewId')
   async editReview(
     @Param('reviewId', ParseIntPipe) reviewId: number,
+    @Query('racketId', ParseIntPipe) racketId: number,
     @Body() body: EditReviewDto,
     @Req() req: RequestWithPassport,
   ) {
     const { userId } = req.user;
-    return await this.reviewsService.editReview(reviewId, body, userId);
+    return await this.reviewsService.editReview(
+      racketId,
+      reviewId,
+      body,
+      userId,
+    );
   }
 
   @HttpCode(204)
@@ -64,9 +70,10 @@ export class ReviewsController {
   @UseGuards(JwtAuthGuard)
   async deleteReview(
     @Param('reviewId', ParseIntPipe) reviewId: number,
+    @Query('racketId', ParseIntPipe) racketId: number,
     @Req() req: RequestWithPassport,
   ) {
     const { userId } = req.user;
-    await this.reviewsService.deleteReview(reviewId, userId);
+    await this.reviewsService.deleteReview(racketId, reviewId, userId);
   }
 }

--- a/backend/src/reviews/reviews.module.ts
+++ b/backend/src/reviews/reviews.module.ts
@@ -3,9 +3,17 @@ import { ReviewsService } from 'reviews/reviews.service';
 import { ReviewsRepository } from 'reviews/reviews.repository';
 import { ReviewsController } from 'reviews/reviews.controller';
 import { RacketsRepository } from 'rackets/rackets.repository';
+import { StatisticsService } from 'statistics/statistics.service';
+import { StatisticsRepository } from 'statistics/statistics.repository';
 
 @Module({
-  providers: [ReviewsService, ReviewsRepository, RacketsRepository],
+  providers: [
+    ReviewsService,
+    ReviewsRepository,
+    RacketsRepository,
+    StatisticsService,
+    StatisticsRepository,
+  ],
   controllers: [ReviewsController],
 })
 export class ReviewsModule {}

--- a/backend/src/reviews/reviews.repository.ts
+++ b/backend/src/reviews/reviews.repository.ts
@@ -6,6 +6,18 @@ import { IReview } from 'reviews/review.interface';
 export class ReviewsRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
+  async getAverageScore(racketId: number) {
+    const averageScore = await this.prismaService.racketReview.aggregate({
+      _avg: {
+        starRating: true,
+      },
+      where: {
+        racketId,
+      },
+    });
+    return Number(averageScore._avg.starRating.toFixed(1));
+  }
+
   async getReviews(racketId: number, page: number) {
     const count = await this.prismaService.racketReview.count({
       where: {
@@ -56,8 +68,12 @@ export class ReviewsRepository {
     });
   }
 
-  async editReview(reviewId: number, review: Partial<IReview>) {
-    return this.prismaService.racketReview.update({
+  async editReview(
+    racketId: number,
+    reviewId: number,
+    review: Partial<IReview>,
+  ) {
+    const result = await this.prismaService.racketReview.update({
       where: {
         id: reviewId,
       },
@@ -65,13 +81,39 @@ export class ReviewsRepository {
         ...review,
       },
     });
+
+    const score = await this.getAverageScore(racketId);
+
+    await this.prismaService.racket.update({
+      where: {
+        id: racketId,
+      },
+      data: {
+        score,
+      },
+    });
+
+    return result;
   }
 
-  async deleteReview(reviewId: number) {
-    return this.prismaService.racketReview.delete({
+  async deleteReview(racketId: number, reviewId: number) {
+    const result = this.prismaService.racketReview.delete({
       where: {
         id: reviewId,
       },
     });
+
+    const score = await this.getAverageScore(racketId);
+
+    await this.prismaService.racket.update({
+      where: {
+        id: racketId,
+      },
+      data: {
+        score,
+      },
+    });
+
+    return result;
   }
 }

--- a/backend/src/reviews/reviews.repository.ts
+++ b/backend/src/reviews/reviews.repository.ts
@@ -59,13 +59,26 @@ export class ReviewsRepository {
   }
 
   async createReview(review: IReview, racketId: number, userId: number) {
-    return this.prismaService.racketReview.create({
+    const result = await this.prismaService.racketReview.create({
       data: {
         ...review,
         racketId,
         userId,
       },
     });
+
+    const score = await this.getAverageScore(racketId);
+
+    await this.prismaService.racket.update({
+      where: {
+        id: racketId,
+      },
+      data: {
+        score,
+      },
+    });
+
+    return result;
   }
 
   async editReview(
@@ -97,7 +110,7 @@ export class ReviewsRepository {
   }
 
   async deleteReview(racketId: number, reviewId: number) {
-    const result = this.prismaService.racketReview.delete({
+    const result = await this.prismaService.racketReview.delete({
       where: {
         id: reviewId,
       },

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -35,6 +35,7 @@ export class ReviewsService {
   }
 
   async editReview(
+    racketId: number,
     reviewId: number,
     updatedReview: Partial<IReview>,
     userId: number,
@@ -44,16 +45,20 @@ export class ReviewsService {
     if (review.userId !== userId)
       throw new ForbiddenException('리뷰를 수정할 권한이 없습니다.');
 
-    return await this.reviewsRepository.editReview(reviewId, updatedReview);
+    return await this.reviewsRepository.editReview(
+      racketId,
+      reviewId,
+      updatedReview,
+    );
   }
 
-  async deleteReview(reviewId: number, userId: number) {
+  async deleteReview(racketId: number, reviewId: number, userId: number) {
     const review = await this.getOneReview(reviewId);
 
     if (review.userId !== userId) {
       throw new ForbiddenException('리뷰를 삭제할 권한이 없습니다.');
     }
 
-    return await this.reviewsRepository.deleteReview(reviewId);
+    return await this.reviewsRepository.deleteReview(racketId, reviewId);
   }
 }

--- a/backend/src/statistics/statistics.controller.spec.ts
+++ b/backend/src/statistics/statistics.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsController } from './statistics.controller';
+
+describe('StatisticsController', () => {
+  let controller: StatisticsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StatisticsController],
+    }).compile();
+
+    controller = module.get<StatisticsController>(StatisticsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/statistics/statistics.controller.ts
+++ b/backend/src/statistics/statistics.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { StatisticsService } from 'statistics/statistics.service';
+
+@Controller('statistics')
+export class StatisticsController {
+  constructor(private readonly statisticsService: StatisticsService) {}
+
+  @Get('/:racketId')
+  async getStatisticsByRacketId(
+    @Param('racketId', ParseIntPipe) racketId: number,
+  ) {
+    return this.statisticsService.getStatisticsByRacketId(racketId);
+  }
+}

--- a/backend/src/statistics/statistics.module.ts
+++ b/backend/src/statistics/statistics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StatisticsController } from 'statistics/statistics.controller';
+import { StatisticsService } from 'statistics/statistics.service';
+import { StatisticsRepository } from 'statistics/statistics.repository';
+
+@Module({
+  providers: [StatisticsService, StatisticsRepository],
+  controllers: [StatisticsController],
+})
+export class StatisticsModule {}

--- a/backend/src/statistics/statistics.repository.ts
+++ b/backend/src/statistics/statistics.repository.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+import { aggregateByField } from 'statistics/utils';
+
+@Injectable()
+export class StatisticsRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getRacketUserGender(racketId: number) {
+    const result = await this.prismaService.user.groupBy({
+      by: ['gender'],
+      _count: {
+        gender: true,
+      },
+
+      where: {
+        Review: {
+          some: {
+            racketId,
+          },
+        },
+      },
+    });
+
+    return aggregateByField(result, 'gender');
+  }
+
+  async getRacketUserRank(racketId: number) {
+    const result = await this.prismaService.user.groupBy({
+      by: ['rank'],
+      _count: {
+        rank: true,
+      },
+
+      where: {
+        Review: {
+          some: {
+            racketId,
+          },
+        },
+      },
+    });
+
+    return aggregateByField(result, 'rank');
+  }
+
+  async getRacketControl(racketId: number) {
+    return this.prismaService.racketReview.count({
+      where: {
+        racketId,
+        control: 1,
+      },
+    });
+  }
+
+  async getRacketPower(racketId: number) {
+    return this.prismaService.racketReview.count({
+      where: {
+        racketId,
+        power: 1,
+      },
+    });
+  }
+
+  async getRacketWeight(racketId: number) {
+    return this.prismaService.racketReview.count({
+      where: {
+        racketId,
+        weight: 1 || 2,
+      },
+    });
+  }
+}

--- a/backend/src/statistics/statistics.repository.ts
+++ b/backend/src/statistics/statistics.repository.ts
@@ -48,7 +48,7 @@ export class StatisticsRepository {
     return this.prismaService.racketReview.count({
       where: {
         racketId,
-        control: 1,
+        control: 0,
       },
     });
   }
@@ -57,7 +57,7 @@ export class StatisticsRepository {
     return this.prismaService.racketReview.count({
       where: {
         racketId,
-        power: 1,
+        power: 0,
       },
     });
   }
@@ -66,7 +66,7 @@ export class StatisticsRepository {
     return this.prismaService.racketReview.count({
       where: {
         racketId,
-        weight: 1 || 2,
+        weight: 0 || 1,
       },
     });
   }

--- a/backend/src/statistics/statistics.service.spec.ts
+++ b/backend/src/statistics/statistics.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatisticsService } from './statistics.service';
+
+describe('StatisticsService', () => {
+  let service: StatisticsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [StatisticsService],
+    }).compile();
+
+    service = module.get<StatisticsService>(StatisticsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { StatisticsRepository } from 'statistics/statistics.repository';
+
+@Injectable()
+export class StatisticsService {
+  constructor(private readonly statisticsRepository: StatisticsRepository) {}
+
+  async getStatisticsByRacketId(racketId: number) {
+    const control = await this.statisticsRepository.getRacketControl(racketId);
+    const power = await this.statisticsRepository.getRacketPower(racketId);
+    const weight = await this.statisticsRepository.getRacketWeight(racketId);
+
+    const genders = await this.statisticsRepository.getRacketUserGender(
+      racketId,
+    );
+
+    const ranks = await this.statisticsRepository.getRacketUserRank(racketId);
+
+    return {
+      criteria: {
+        control,
+        power,
+        weight,
+      },
+      genders,
+      ranks,
+    };
+  }
+}

--- a/backend/src/statistics/utils.ts
+++ b/backend/src/statistics/utils.ts
@@ -1,0 +1,7 @@
+export const aggregateByField = (arr, field) => {
+  const result = arr.reduce((obj, item) => {
+    obj[item[field]] = item._count[field.toLowerCase()];
+    return obj;
+  }, {});
+  return result;
+};

--- a/frontend/components/charts/HalfPieChart.jsx
+++ b/frontend/components/charts/HalfPieChart.jsx
@@ -1,0 +1,34 @@
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from "recharts";
+
+const HalfPieChart = ({ data, title, isAnimated = true }) => {
+  return (
+    <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4 border-2">
+      <p className="mb-2 text-xl font-bold">{title}</p>
+      <ResponsiveContainer width="100%" height="100%">
+        <PieChart>
+          <Legend />
+          <Pie
+            animationBegin={isAnimated}
+            outerRadius={100}
+            innerRadius={70}
+            startAngle={0}
+            endAngle={180}
+            paddingAngle={5}
+            data={data}
+            dataKey="value"
+            cx="50%"
+            cy="50%"
+            fill="#8884d8"
+            label
+          >
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.filled} />
+            ))}
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default HalfPieChart;

--- a/frontend/components/charts/HalfPieChart.jsx
+++ b/frontend/components/charts/HalfPieChart.jsx
@@ -1,4 +1,4 @@
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from "recharts";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
 const HalfPieChart = ({ data, title, isAnimated = true }) => {
   return (
@@ -7,6 +7,7 @@ const HalfPieChart = ({ data, title, isAnimated = true }) => {
       <div className="w-[328px] h-[328px]  border-2">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
+            <Tooltip/>
             <Legend />
             <Pie
               animationBegin={isAnimated}

--- a/frontend/components/charts/HalfPieChart.jsx
+++ b/frontend/components/charts/HalfPieChart.jsx
@@ -2,31 +2,30 @@ import { Cell, Legend, Pie, PieChart, ResponsiveContainer } from "recharts";
 
 const HalfPieChart = ({ data, title, isAnimated = true }) => {
   return (
-    <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4 border-2">
+    <div>
       <p className="mb-2 text-xl font-bold">{title}</p>
-      <ResponsiveContainer width="100%" height="100%">
-        <PieChart>
-          <Legend />
-          <Pie
-            animationBegin={isAnimated}
-            outerRadius={100}
-            innerRadius={70}
-            startAngle={0}
-            endAngle={180}
-            paddingAngle={5}
-            data={data}
-            dataKey="value"
-            cx="50%"
-            cy="50%"
-            fill="#8884d8"
-            label
-          >
-            {data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.filled} />
-            ))}
-          </Pie>
-        </PieChart>
-      </ResponsiveContainer>
+      <div className="w-[328px] h-[328px]  border-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Legend />
+            <Pie
+              animationBegin={isAnimated}
+              outerRadius={100}
+              innerRadius={70}
+              paddingAngle={5}
+              data={data}
+              dataKey="value"
+              cx="50%"
+              cy="50%"
+              fill="#8884d8"
+            >
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.filled} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/frontend/components/charts/HalfPieChart.jsx
+++ b/frontend/components/charts/HalfPieChart.jsx
@@ -1,16 +1,22 @@
-import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
 
-const HalfPieChart = ({ data, title, isAnimated = true }) => {
+const HalfPieChart = ({ data, title }) => {
   return (
     <div>
       <p className="mb-2 text-xl font-bold">{title}</p>
       <div className="w-[328px] h-[328px]  border-2">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
-            <Tooltip/>
+            <Tooltip />
             <Legend />
             <Pie
-              animationBegin={isAnimated}
               outerRadius={100}
               innerRadius={70}
               paddingAngle={5}

--- a/frontend/components/charts/SimpleBarChart.tsx
+++ b/frontend/components/charts/SimpleBarChart.tsx
@@ -1,7 +1,13 @@
-import { Bar, BarChart, Cell, Legend, ResponsiveContainer } from "recharts";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+} from "recharts";
 
 const SimpleBarChart = ({ data, title }) => {
-  console.log(data);
   return (
     <div>
       <p className="mb-2 text-xl font-bold">{title}</p>

--- a/frontend/components/charts/SimpleBarChart.tsx
+++ b/frontend/components/charts/SimpleBarChart.tsx
@@ -1,0 +1,20 @@
+import { Bar, BarChart, Cell, Legend, ResponsiveContainer } from "recharts";
+
+const SimpleBarChart = ({ data, title }) => {
+  return (
+    <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4 border-2">
+      <p className="mb-2 text-xl font-bold">{title}</p>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <Legend />
+          <Bar dataKey="value" label>
+            {data.map((entry, index) => (
+              <Cell key={`cell-${index}`} fill={entry.filled} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+export default SimpleBarChart;

--- a/frontend/components/charts/SimpleBarChart.tsx
+++ b/frontend/components/charts/SimpleBarChart.tsx
@@ -2,25 +2,38 @@ import {
   Bar,
   BarChart,
   Cell,
+  LabelList,
   Legend,
   ResponsiveContainer,
   Tooltip,
+  XAxis,
 } from "recharts";
 
 const SimpleBarChart = ({ data, title }) => {
   return (
     <div>
       <p className="mb-2 text-xl font-bold">{title}</p>
-      <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4 border-2">
+      <div className="w-[328px] h-[328px]  border-2">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data}>
+            <XAxis dataKey="name" />
             <Legend
               payload={data.map((d) => ({ value: d.name, color: d.filled }))}
+            />
+
+            <Tooltip
+              formatter={(value) => `${value}명`}
+              labelFormatter={(value) => `${value} 좋아요`}
+              payload={data.map((d) => ({
+                name: d.name,
+                value: d.value,
+              }))}
             />
             <Bar dataKey="value">
               {data.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={entry.filled} />
               ))}
+              <LabelList dataKey="value" position="top" />
             </Bar>
           </BarChart>
         </ResponsiveContainer>

--- a/frontend/components/charts/SimpleBarChart.tsx
+++ b/frontend/components/charts/SimpleBarChart.tsx
@@ -1,19 +1,24 @@
 import { Bar, BarChart, Cell, Legend, ResponsiveContainer } from "recharts";
 
 const SimpleBarChart = ({ data, title }) => {
+  console.log(data);
   return (
-    <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4 border-2">
+    <div>
       <p className="mb-2 text-xl font-bold">{title}</p>
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data}>
-          <Legend />
-          <Bar dataKey="value" label>
-            {data.map((entry, index) => (
-              <Cell key={`cell-${index}`} fill={entry.filled} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+      <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4 border-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <Legend
+              payload={data.map((d) => ({ value: d.name, color: d.filled }))}
+            />
+            <Bar dataKey="value">
+              {data.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.filled} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -1,5 +1,4 @@
 import EvaluateButton from "components/common/EvaluateButton";
-import { RacketDetailProps } from "interface/RacketDetail.interface";
 import { Rating } from "react-simple-star-rating";
 
 import Review from "components/rackets/Review";
@@ -79,7 +78,7 @@ const RacketDetail = () => {
           </section>
         </div>
 
-        <section className="">
+        <section className="mx-auto max-md:flex max-md:flex-col max-md:items-center">
           <p className="my-4 text-2xl font-bold">라켓 데이터</p>
           <div className="md:flex md:justify-between">
             <HalfPieChart

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -21,6 +21,7 @@ import { useRouter } from "next/router";
 import HalfPieChart from "components/charts/HalfPieChart";
 import SimpleBarChart from "components/charts/SimpleBarChart";
 import { useReviewStatistics } from "query/reviews/statistics";
+import { useRacketQuery } from "query/rackets/rackets";
 
 const MODAL_TYPE = Object.freeze({
   CLOSE: null,
@@ -30,14 +31,17 @@ const MODAL_TYPE = Object.freeze({
 
 const isModalOpen = (value: null | string) => value !== null;
 
-const RacketDetail = ({ racketName }: RacketDetailProps) => {
-  const { data } = useReviewList();
+const RacketDetail = () => {
+  const { data: racket } = useRacketQuery();
+  const { data: reviewList } = useReviewList();
   const { data: reviewStatistics } = useReviewStatistics();
 
   const user = useRecoilValue(userState);
   const [modalState, setModalState] = useState<null | string>(MODAL_TYPE.CLOSE);
   const [reviewId, setReviewId] = useState<null | number>(null);
   const router = useRouter();
+
+  console.log(racket);
 
   const { mutate: deleteRacketReview } = useDeleteRacketReviewMutation();
 
@@ -46,7 +50,7 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
   return (
     <Fragment>
       <div className="px-4 max-w-[1200px] mx-auto mb-9">
-        <h1 className="my-10 text-3xl font-bold">{racketName}</h1>
+        <h1 className="my-10 text-3xl font-bold">{racket.name}</h1>
         <div className="justify-between mx-auto md:flex ">
           <section className="my-4 md:w-1/2">
             <img
@@ -59,13 +63,13 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
             <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4">
               <p className="text-2xl font-bold">평균 별점</p>
               <Rating
-                initialValue={4.4}
+                initialValue={racket.score}
                 readonly
                 allowFraction
                 emptyStyle={{ display: "flex" }}
                 fillStyle={{ display: "-webkit-inline-box" }}
               />
-              <p className="text-3xl font-bold">4.4</p>
+              <p className="text-3xl font-bold">{racket.score}</p>
             </div>
             {true && (
               <EvaluateButton
@@ -96,8 +100,8 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
         <section className="mx-auto">
           <p className="my-4 text-2xl font-bold">리뷰</p>
           <div className="flex flex-col gap-y-2">
-            {data?.reviewList?.length ? (
-              data?.reviewList?.map((review) => (
+            {reviewList?.reviewList?.length ? (
+              reviewList?.reviewList?.map((review) => (
                 <Review
                   key={review.id}
                   review={review.review}
@@ -125,12 +129,14 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
             )}
           </div>
         </section>
-        <div className="sm:flex sm:justify-center sm:mt-4">
-          <Pagination
-            curPage={curPage}
-            totalPage={Math.ceil(data?.count / 7)}
-          />
-        </div>
+        {reviewList?.count > 7 ? (
+          <div className="sm:flex sm:justify-center sm:mt-4">
+            <Pagination
+              curPage={curPage}
+              totalPage={Math.ceil(reviewList?.count / 7)}
+            />
+          </div>
+        ) : null}
       </div>
 
       <Modal isOpen={isModalOpen(modalState)}>

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -20,6 +20,7 @@ import Pagination from "components/common/Pagination";
 import { useRouter } from "next/router";
 import HalfPieChart from "components/charts/HalfPieChart";
 import SimpleBarChart from "components/charts/SimpleBarChart";
+import { useReviewStatistics } from "query/reviews/statistics";
 
 const MODAL_TYPE = Object.freeze({
   CLOSE: null,
@@ -41,15 +42,16 @@ const data02 = [
 ];
 
 const data03 = [
-  { name: "컨트롤이 좋아요", value: 9, filled: "#FFBB28" },
-  { name: "파워가 좋아요", value: 10, filled: "#00C49F" },
-  { name: "무게가 가벼워요", value: 32, filled: "#F43F5E" },
+  { name: "컨트롤", value: 9, filled: "#FFBB28" },
+  { name: "파워", value: 10, filled: "#00C49F" },
+  { name: "무게", value: 32, filled: "#F43F5E" },
 ];
 
 const isModalOpen = (value: null | string) => value !== null;
 
 const RacketDetail = ({ racketName }: RacketDetailProps) => {
   const { data } = useReviewList();
+  const { data: reviewStatistics } = useReviewStatistics();
 
   const user = useRecoilValue(userState);
   const [modalState, setModalState] = useState<null | string>(MODAL_TYPE.CLOSE);
@@ -84,7 +86,7 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
               />
               <p className="text-3xl font-bold">4.4</p>
             </div>
-            {user && (
+            {true && (
               <EvaluateButton
                 handleClick={() => setModalState(MODAL_TYPE.CREATE)}
               />
@@ -95,9 +97,18 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
         <section className="">
           <p className="my-4 text-2xl font-bold">라켓 데이터</p>
           <div className="md:flex md:justify-between">
-            <HalfPieChart data={data01} title="남녀 성별 비율" />
-            <HalfPieChart data={data02} title="사용 급수 비율" />
-            <SimpleBarChart data={data03} title="라켓 기능 평가" />
+            <HalfPieChart
+              data={reviewStatistics?.gender}
+              title="남녀 성별 비율"
+            />
+            <HalfPieChart
+              data={reviewStatistics?.rank}
+              title="사용 급수 비율"
+            />
+            <SimpleBarChart
+              data={reviewStatistics?.criteria}
+              title="라켓 선택 이유"
+            />
           </div>
         </section>
 

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -41,7 +41,7 @@ const data02 = [
 ];
 
 const data03 = [
-  { name: "컨트롤이 좋아요", value: 83, filled: "#FFBB28" },
+  { name: "컨트롤이 좋아요", value: 9, filled: "#FFBB28" },
   { name: "파워가 좋아요", value: 10, filled: "#00C49F" },
   { name: "무게가 가벼워요", value: 32, filled: "#F43F5E" },
 ];
@@ -60,16 +60,6 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
 
   const curPage = Number.parseInt(router.query.page as string) || 1;
 
-  /**
-   * {user && (
-              <EvaluateButton
-                handleClick={() => setModalState(MODAL_TYPE.CREATE)}
-              />
-            )}
-
-
-
-   */
   return (
     <Fragment>
       <div className="px-4 max-w-[1200px] mx-auto mb-9">
@@ -94,6 +84,11 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
               />
               <p className="text-3xl font-bold">4.4</p>
             </div>
+            {user && (
+              <EvaluateButton
+                handleClick={() => setModalState(MODAL_TYPE.CREATE)}
+              />
+            )}
           </section>
         </div>
 

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -28,25 +28,6 @@ const MODAL_TYPE = Object.freeze({
   EDIT: "EDIT",
 });
 
-const data01 = [
-  { name: "남성", value: 10, filled: "#6366F1" },
-  { name: "여성", value: 4, filled: "#F43F5E" },
-];
-
-const data02 = [
-  { name: "S조", value: 10, filled: "#FF8042" },
-  { name: "A조", value: 4, filled: "#FFBB28" },
-  { name: "B조", value: 4, filled: "#00C49F" },
-  { name: "C조", value: 4, filled: "#0088FE" },
-  { name: "D조", value: 4, filled: "#F43F5E" },
-];
-
-const data03 = [
-  { name: "컨트롤", value: 9, filled: "#FFBB28" },
-  { name: "파워", value: 10, filled: "#00C49F" },
-  { name: "무게", value: 32, filled: "#F43F5E" },
-];
-
 const isModalOpen = (value: null | string) => value !== null;
 
 const RacketDetail = ({ racketName }: RacketDetailProps) => {
@@ -98,11 +79,11 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
           <p className="my-4 text-2xl font-bold">라켓 데이터</p>
           <div className="md:flex md:justify-between">
             <HalfPieChart
-              data={reviewStatistics?.gender}
+              data={reviewStatistics?.genders}
               title="남녀 성별 비율"
             />
             <HalfPieChart
-              data={reviewStatistics?.rank}
+              data={reviewStatistics?.ranks}
               title="사용 급수 비율"
             />
             <SimpleBarChart

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -1,6 +1,7 @@
 import EvaluateButton from "components/common/EvaluateButton";
 import { RacketDetailProps } from "interface/RacketDetail.interface";
-import Chart from "components/rackets/Chart";
+import { Rating } from "react-simple-star-rating";
+
 import Review from "components/rackets/Review";
 import { Fragment, useState } from "react";
 import Modal from "components/common/Modal";
@@ -17,12 +18,33 @@ import { birthdayToAge } from "utils/birthdayToage";
 import { ko } from "date-fns/locale";
 import Pagination from "components/common/Pagination";
 import { useRouter } from "next/router";
+import HalfPieChart from "components/charts/HalfPieChart";
+import SimpleBarChart from "components/charts/SimpleBarChart";
 
 const MODAL_TYPE = Object.freeze({
   CLOSE: null,
   CREATE: "CREATE",
   EDIT: "EDIT",
 });
+
+const data01 = [
+  { name: "남성", value: 10, filled: "#6366F1" },
+  { name: "여성", value: 4, filled: "#F43F5E" },
+];
+
+const data02 = [
+  { name: "S조", value: 10, filled: "#FF8042" },
+  { name: "A조", value: 4, filled: "#FFBB28" },
+  { name: "B조", value: 4, filled: "#00C49F" },
+  { name: "C조", value: 4, filled: "#0088FE" },
+  { name: "D조", value: 4, filled: "#F43F5E" },
+];
+
+const data03 = [
+  { name: "컨트롤이 좋아요", value: 83, filled: "#FFBB28" },
+  { name: "파워가 좋아요", value: 10, filled: "#00C49F" },
+  { name: "무게가 가벼워요", value: 32, filled: "#F43F5E" },
+];
 
 const isModalOpen = (value: null | string) => value !== null;
 
@@ -38,6 +60,16 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
 
   const curPage = Number.parseInt(router.query.page as string) || 1;
 
+  /**
+   * {user && (
+              <EvaluateButton
+                handleClick={() => setModalState(MODAL_TYPE.CREATE)}
+              />
+            )}
+
+
+
+   */
   return (
     <Fragment>
       <div className="px-4 max-w-[1200px] mx-auto mb-9">
@@ -51,16 +83,29 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
             />
           </section>
           <section className="w-[328px] mx-auto md:w-1/2 md:flex md:flex-col md:items-center  ">
-            <div className="w-[328px] h-[328px] border-2 my-4 flex items-center">
-              <Chart />
-            </div>
-            {user && (
-              <EvaluateButton
-                handleClick={() => setModalState(MODAL_TYPE.CREATE)}
+            <div className="w-[328px] h-[328px]  my-4 flex flex-col items-center justify-center gap-y-4">
+              <p className="text-2xl font-bold">평균 별점</p>
+              <Rating
+                initialValue={4.4}
+                readonly
+                allowFraction
+                emptyStyle={{ display: "flex" }}
+                fillStyle={{ display: "-webkit-inline-box" }}
               />
-            )}
+              <p className="text-3xl font-bold">4.4</p>
+            </div>
           </section>
         </div>
+
+        <section className="">
+          <p className="my-4 text-2xl font-bold">라켓 데이터</p>
+          <div className="md:flex md:justify-between">
+            <HalfPieChart data={data01} title="남녀 성별 비율" />
+            <HalfPieChart data={data02} title="사용 급수 비율" />
+            <SimpleBarChart data={data03} title="라켓 기능 평가" />
+          </div>
+        </section>
+
         <section className="mx-auto">
           <p className="my-4 text-2xl font-bold">리뷰</p>
           <div className="flex flex-col gap-y-2">
@@ -100,6 +145,7 @@ const RacketDetail = ({ racketName }: RacketDetailProps) => {
           />
         </div>
       </div>
+
       <Modal isOpen={isModalOpen(modalState)}>
         {modalState === MODAL_TYPE.CREATE ? (
           <CreateReview

--- a/frontend/interface/Statistics.interface.ts
+++ b/frontend/interface/Statistics.interface.ts
@@ -1,0 +1,34 @@
+export interface IReviewStatisticsResponse {
+  criteria: {
+    control: number;
+    power: number;
+    weight: number;
+  };
+  ranks: {
+    S: number;
+    A: number;
+    B: number;
+    C: number;
+    D: number;
+  };
+  genders: {
+    MALE: number;
+    FEMALE: number;
+  };
+}
+
+type gender = "남성" | "여성";
+type rank = "S조" | "A조" | "B조" | "C조" | "D조";
+type criteria = "컨트롤" | "파워" | "무게";
+
+export interface ISelectedStatistics {
+  name: gender | rank | criteria;
+  value: number;
+  filled: string;
+}
+
+export interface IStatistics {
+  name: string;
+  value: number;
+  filled: string;
+}

--- a/frontend/interface/Statistics.interface.ts
+++ b/frontend/interface/Statistics.interface.ts
@@ -28,7 +28,7 @@ export interface ISelectedStatistics {
 }
 
 export interface IStatistics {
-  name: string;
-  value: number;
-  filled: string;
+  criteria: ISelectedStatistics[];
+  genders: ISelectedStatistics[];
+  ranks: ISelectedStatistics[];
 }

--- a/frontend/query/queryKeys.ts
+++ b/frontend/query/queryKeys.ts
@@ -19,4 +19,9 @@ export const queryKeys = Object.freeze({
     ],
     single: (reviewId: number | undefined) => ["reviews", "single", reviewId],
   },
+
+  statistics: {
+    all: ["statistics"],
+    single: (racketId: number) => [...queryKeys.statistics.all, racketId],
+  },
 });

--- a/frontend/query/queryKeys.ts
+++ b/frontend/query/queryKeys.ts
@@ -2,17 +2,22 @@ export const queryKeys = Object.freeze({
   auth: {
     all: ["auth"],
     tokenState: ["auth", "tokenState"],
-    emailToken: (token: string) => ["auth", "emailToken", token],
+    emailToken: (token: string) => [...queryKeys.auth.all, "emailToken", token],
   },
   rackets: {
     all: ["rackets"],
     list: (brand: any, page: any) => ["rackets", "list", brand, { page }],
+    single: (racketId: number) => [
+      ...queryKeys.rackets.all,
+      "single",
+      racketId,
+    ],
   },
 
   reviews: {
     all: ["reviews"],
     list: (racketId: number | undefined, page: number) => [
-      "reviews",
+      ...queryKeys.reviews.all,
       "list",
       racketId,
       page,

--- a/frontend/query/rackets/rackets.ts
+++ b/frontend/query/rackets/rackets.ts
@@ -24,3 +24,22 @@ export const useRacketListQuery = () => {
     { suspense: true, staleTime: 5 * 60 * 1000 },
   );
 };
+
+const getRacket = async (racketId: number): Promise<any> => {
+  const { data } = await axios.get(`/rackets/${racketId}/detail`);
+  return data;
+};
+
+export const useRacketQuery = () => {
+  const router = useRouter();
+  const racketId = Number.parseInt(router.query.racketId as string);
+
+  return useQuery(
+    queryKeys.rackets.single(racketId),
+    () => getRacket(racketId),
+    {
+      suspense: true,
+      enabled: Number.isNaN(racketId) === false,
+    },
+  );
+};

--- a/frontend/query/reviews/reviews.ts
+++ b/frontend/query/reviews/reviews.ts
@@ -103,7 +103,7 @@ export const useCreateRacketReviewMutation = () => {
       createRacketReview(racketId, reviewForm),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(queryKeys.reviews.all);
+        queryClient.invalidateQueries();
         alert("리뷰가 생성되었습니다");
       },
     },

--- a/frontend/query/reviews/reviews.ts
+++ b/frontend/query/reviews/reviews.ts
@@ -18,7 +18,7 @@ const getRacketReviewList = async (racketId: number, page: number) => {
   return data;
 };
 
-const getRacketReview = async (reviewId: number | null) => {
+const getRacketReview = async (reviewId: number | undefined) => {
   const { data } = await axios.get(`/reviews/${reviewId}`);
   return data;
 };
@@ -34,17 +34,30 @@ const createRacketReview = async (
 };
 
 const editRacketReview = async (
+  racketId: number,
   reviewId: number,
   reviewForm: ICreateOrEditReview,
 ) => {
-  const { data } = await axios.patch(`/reviews/${reviewId}`, {
-    ...reviewForm,
-  });
+  const { data } = await axios.patch(
+    `/reviews/${reviewId}`,
+    {
+      ...reviewForm,
+    },
+    {
+      params: {
+        racketId,
+      },
+    },
+  );
   return data;
 };
 
-const deleteRacketReview = async (reviewId: number) => {
-  const { data } = await axios.delete(`/reviews/${reviewId}`);
+const deleteRacketReview = async (racketId: number, reviewId: number) => {
+  const { data } = await axios.delete(`/reviews/${reviewId}`, {
+    params: {
+      racketId,
+    },
+  });
   return data;
 };
 
@@ -69,12 +82,12 @@ export const useReviewList = () => {
   );
 };
 
-export const useRacketReview = (reviewId: number | null) => {
+export const useRacketReview = (reviewId: number | undefined) => {
   return useQuery<IReviewResponse>(
     queryKeys.reviews.single(reviewId),
     () => getRacketReview(reviewId),
     {
-      enabled: reviewId !== null,
+      enabled: reviewId !== undefined,
       suspense: true,
     },
   );
@@ -102,12 +115,15 @@ export const useEditRacketReviewMutation = (
   mutationConfig: IMutationConfig,
 ) => {
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const racketId = Number(router.query.racketId);
 
   return useMutation(
-    (reviewForm: ICreateOrEditReview) => editRacketReview(reviewId, reviewForm),
+    (reviewForm: ICreateOrEditReview) =>
+      editRacketReview(racketId, reviewId, reviewForm),
     {
       onSuccess: () => {
-        queryClient.invalidateQueries(queryKeys.reviews.all);
+        queryClient.invalidateQueries();
         mutationConfig.onSuccess();
         alert("리뷰가 수정되었습니다.");
       },
@@ -117,11 +133,16 @@ export const useEditRacketReviewMutation = (
 
 export const useDeleteRacketReviewMutation = () => {
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const racketId = Number(router.query.racketId);
 
-  return useMutation((reviewId: number) => deleteRacketReview(reviewId), {
-    onSuccess: () => {
-      queryClient.invalidateQueries();
-      alert("리뷰가 삭제되었습니다");
+  return useMutation(
+    (reviewId: number) => deleteRacketReview(racketId, reviewId),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries();
+        alert("리뷰가 삭제되었습니다");
+      },
     },
-  });
+  );
 };

--- a/frontend/query/reviews/statistics.ts
+++ b/frontend/query/reviews/statistics.ts
@@ -1,0 +1,92 @@
+import { useQuery } from "@tanstack/react-query";
+import { IReviewStatisticsResponse } from "interface/Statistics.interface";
+import { useRouter } from "next/router";
+import axios from "query/axios";
+import { queryKeys } from "query/queryKeys";
+
+const statisticsPropertyMapper = {
+  criteria: {
+    control: "컨트롤",
+    power: "파워",
+    weight: "무게",
+  },
+  ranks: {
+    S: "S조",
+    A: "A조",
+    B: "B조",
+    C: "C조",
+    D: "D조",
+  },
+  genders: {
+    MALE: "남성",
+    FEMALE: "여성",
+  },
+} as const;
+
+const colorMaper = {
+  criteria: {
+    control: "#FFBB28",
+    power: "#00C49F",
+    weight: "#F43F5E",
+  },
+  gender: {
+    MALE: "#6366F1",
+    FEMALE: "#F43F5E",
+  },
+  rank: {
+    S: "#FF8042",
+    A: "#FFBB28",
+    B: "#00C49F",
+    C: "#0088FE",
+    D: "#F43F5E",
+  },
+};
+
+const getReviewStatistics = async (racketId: number) => {
+  const { data } = await axios(`/statistics/${racketId}`);
+  return data;
+};
+
+export const useReviewStatistics = () => {
+  const router = useRouter();
+  const racketId = Number.parseInt(router.query.racketId);
+
+  return useQuery<IReviewStatisticsResponse>(
+    queryKeys.statistics.single(racketId),
+    () => getReviewStatistics(racketId),
+    {
+      enabled: !!racketId,
+      select: (data) => {
+        const { criteria, genders, ranks } = data;
+
+        const transformedCriteria = Object.entries(criteria).map(
+          ([key, value]) => ({
+            name: statisticsPropertyMapper.criteria[key],
+            value,
+            filled: colorMaper.criteria[key],
+          }),
+        );
+
+        const transformedGender = Object.entries(genders).map(
+          ([key, value]) => ({
+            name: statisticsPropertyMapper.genders[key],
+            value,
+            filled: colorMaper.gender[key],
+          }),
+        );
+
+        const transformedRank = Object.entries(ranks).map(([key, value]) => ({
+          name: statisticsPropertyMapper.ranks[key],
+          value,
+          filled: colorMaper.rank[key],
+        }));
+
+        return {
+          criteria: transformedCriteria,
+          gender: transformedGender,
+          rank: transformedRank,
+        };
+      },
+    },
+  );
+};


### PR DESCRIPTION
## 설명

라켓 상세 페이지에 필요한 api를 생성하고, FE와 연동합니다.

## 관련 이슈

Fix #84 

## 변경사항

**BE**
- 리뷰 생성 / 수정 / 삭제에 대해 racket의 score를 업데이트 하는 쿼리 추가

**FE**
- 라켓 상세 페이지와 관련된 api 추가

## 스크린샷
![image](https://user-images.githubusercontent.com/48270642/235618282-29fa2f9c-6311-400c-84f8-18f31e8dcf9b.png)

