### PR TITLE
feat: add private routes

### DIFF
--- a/frontend/__tests__/Login.test.tsx
+++ b/frontend/__tests__/Login.test.tsx
@@ -1,0 +1,45 @@
+import { render } from "@testing-library/react";
+import { useRouter } from "next/router";
+import Login from "pages/login";
+import { RecoilRoot } from "recoil";
+import { userState } from "recoil/atoms/user";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({
+    mutate: jest.fn(),
+  }),
+  QueryClientProvider: jest.fn(),
+}));
+
+describe("로그인 페이지 접근 가능 여부를 테스트 합니다.", () => {
+  it("로그인 되지 않은 경우, 접근 가능합니다.", () => {
+    render(
+      <RecoilRoot initializeState={({ set }) => set(userState, null)}>
+        <Login />
+      </RecoilRoot>,
+    );
+  });
+
+  it("로그인 된 경우, 접근이 불가능합니다.", () => {
+    const pushMock = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: pushMock,
+    });
+
+    render(
+      <RecoilRoot
+        initializeState={({ set }) =>
+          set(userState, { email: "test@test.com", id: 1 })
+        }
+      >
+        <Login />
+      </RecoilRoot>,
+    );
+
+    expect(useRouter().push).toBeCalledWith("/");
+  });
+});

--- a/frontend/components/common/EmailSend.stories.tsx
+++ b/frontend/components/common/EmailSend.stories.tsx
@@ -2,6 +2,9 @@ import EmailSend from "components/common/EmailSend";
 
 export default {
   component: EmailSend,
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
 };
 
 export const Default = () => <EmailSend />;

--- a/frontend/jest.config.mjs
+++ b/frontend/jest.config.mjs
@@ -4,6 +4,7 @@ import nextJest from "next/jest.js";
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
   dir: "./",
+  
 });
 
 // Add any custom config to be passed to Jest
@@ -13,6 +14,7 @@ const config = {
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 
   testEnvironment: "jest-environment-jsdom",
+  moduleDirectories:["node_modules", "frontend"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,9 +1,10 @@
 import LoginForms from "components/forms/LoginForms";
 import { NextPage } from "next";
+import { OnlyPublicRoute } from "utils/conditionalRoutes";
 
 const Login: NextPage = () => (
   <div className="h-screen">
     <LoginForms />
   </div>
 );
-export default Login;
+export default OnlyPublicRoute(Login);

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -3,6 +3,7 @@ import Spinner from "components/common/Spinner";
 import dynamic from "next/dynamic";
 import { ErrorBoundary } from "react-error-boundary";
 import BadRequest from "components/common/BadRequest";
+import { OnlyPublicRoute } from "utils/conditionalRoutes";
 
 const SignupForms = dynamic(() => import("components/forms/SignupForms"), {
   loading: () => <Spinner />,
@@ -14,4 +15,4 @@ const Signup = () => (
     <SignupForms />
   </ErrorBoundary>
 );
-export default Signup;
+export default OnlyPublicRoute(Signup);

--- a/frontend/utils/conditionalRoutes.tsx
+++ b/frontend/utils/conditionalRoutes.tsx
@@ -1,0 +1,35 @@
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useRecoilValue } from "recoil";
+import { userState } from "recoil/atoms/user";
+
+export const OnlyPublicRoute = (Component: NextPage) => {
+  const PublicRoute = () => {
+    const router = useRouter();
+    const user = useRecoilValue(userState);
+
+    if (user) {
+      router.push("/");
+      return null;
+    }
+
+    return <Component />;
+  };
+
+  return PublicRoute;
+};
+
+export const PrivateRoute = (Component: NextPage) => {
+  const PrivateRoute = () => {
+    const router = useRouter();
+    const user = useRecoilValue(userState);
+
+    if (user) {
+      return <Component />;
+    }
+
+    router.push("/login");
+    return null;
+  };
+  return PrivateRoute;
+};


### PR DESCRIPTION
## 설명

로그인 여부에 따라 접근 가능 여부가 달라지는 페이지에 대해서 Private Route를 적용합니다.

## 관련 이슈

Fix #89 

## 변경사항

`/utils/conditionalRoute.ts` 를 추가하였습니다.

로그인 된 상태에서 login / signup 페이지로 접근하는 경우 모두 메인 화면으로 redirect 시킵니다.

로그인 여부에 따라 `router.push` 함수가 호출되는 여부를 파악하는 테스트를 작성했습니다.

## 스크린샷
없음
