### PR TITLE
feat: add youtube videos

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# env
+.env*

--- a/frontend/components/carousels/MainRacketCarousel.tsx
+++ b/frontend/components/carousels/MainRacketCarousel.tsx
@@ -1,9 +1,8 @@
 import Racket from "components/rackets/Racket";
+import useClientWidth from "hooks/useClientWidth";
 import { IRacket } from "interface/Racket.interface";
 import { useRacketListQuery } from "query/rackets/rackets";
-import { useEffect, useState } from "react";
 import Slider, { Settings } from "react-slick";
-import { debounce } from "utils/debounce";
 
 export interface MainRacketCarouselProps {
   clientWidth: number;
@@ -15,19 +14,7 @@ export interface MainRacketCarouselProps {
 
 const MainRacketCarousel = () => {
   const { data } = useRacketListQuery();
-
-  const [clientWidth, setClientWidth] = useState(
-    document.documentElement.clientWidth,
-  );
-
-  const handleResize = () =>
-    setClientWidth(document.documentElement.clientWidth);
-
-  useEffect(() => {
-    addEventListener("resize", debounce(handleResize));
-
-    return removeEventListener("resize", () => {});
-  }, []);
+  const clientWidth = useClientWidth();
 
   return <MainRacketCarouselView clientWidth={clientWidth} rackets={data} />;
 };

--- a/frontend/components/reviews/SelectBoxList.stories.tsx
+++ b/frontend/components/reviews/SelectBoxList.stories.tsx
@@ -1,12 +1,13 @@
-import SelectBoxList, { ISelectItem } from "components/reviews/SelectBoxList";
+import SelectBoxList from "components/reviews/SelectBoxList";
+import { formIdType, ISelectListValue } from "interface/SelectBox.interface";
 
 export default {
   component: SelectBoxList,
 };
 
 export const Default = (args: {
-  selectList: ISelectItem[];
-  formId: string;
+  selectList: ISelectListValue<formIdType>;
+  formId: formIdType;
 }) => (
   <div className="flex w-mb">
     <SelectBoxList {...args} />

--- a/frontend/components/videos/YoutubeVideo.stories.tsx
+++ b/frontend/components/videos/YoutubeVideo.stories.tsx
@@ -1,0 +1,29 @@
+import YoutubeVideo from "components/videos/YoutubeVideo";
+import { IYoutubeSearchItem } from "interface/Youtube.interface";
+
+export default {
+  component: YoutubeVideo,
+};
+
+export const Default = (args: IYoutubeSearchItem) => <YoutubeVideo {...args} />;
+
+Default.args = {
+  id: {
+    videoId: "Q1XZ6zq6EO4",
+  },
+  snippet: {
+    title: "테스트 배드민턴 영상",
+    channelTitle: "테스트 배드민턴 채널",
+    thumbnails: {
+      medium: {
+        url: "https://i.ytimg.com/vi/Q1XZ6zq6EO4/mqdefault_live.jpg",
+      },
+    },
+  },
+};
+
+Default.argTypes = {
+  id: { disable: { table: true } },
+  kind: { disable: { table: true } },
+  etag: { disable: { table: true } },
+};

--- a/frontend/components/videos/YoutubeVideo.tsx
+++ b/frontend/components/videos/YoutubeVideo.tsx
@@ -1,0 +1,27 @@
+import { IYoutubeSearchItem } from "interface/Youtube.interface";
+import React from "react";
+
+const videoBaseUrl = "https://www.youtube.com/watch?v=";
+
+const YoutubeVideo = ({ snippet, id }: IYoutubeSearchItem): JSX.Element => {
+  return (
+    <div className="overflow-hidden transition-all border-2 rounded-lg w-80 hover:bg-slate-100 ">
+      <a href={videoBaseUrl + id.videoId} target="_blank" rel="noreferrer">
+        <div className="flex justify-center">
+          <img
+            width={320}
+            height={180}
+            className="object-cover"
+            src={snippet.thumbnails.medium.url}
+            alt="thumnail"
+          />
+        </div>
+        <div className="pl-1">
+          <p className="font-semibold">{snippet.title}</p>
+          <p className="text-sm">{snippet.channelTitle}</p>
+        </div>
+      </a>
+    </div>
+  );
+};
+export default YoutubeVideo;

--- a/frontend/components/videos/YoutubeVideo.tsx
+++ b/frontend/components/videos/YoutubeVideo.tsx
@@ -17,7 +17,7 @@ const YoutubeVideo = ({ snippet, id }: IYoutubeSearchItem): JSX.Element => {
           />
         </div>
         <div className="pl-1">
-          <p className="font-semibold">{snippet.title}</p>
+          <p className="font-semibold truncate">{snippet.title}</p>
           <p className="text-sm">{snippet.channelTitle}</p>
         </div>
       </a>

--- a/frontend/components/videos/YoutubeVideo.tsx
+++ b/frontend/components/videos/YoutubeVideo.tsx
@@ -5,7 +5,7 @@ const videoBaseUrl = "https://www.youtube.com/watch?v=";
 
 const YoutubeVideo = ({ snippet, id }: IYoutubeSearchItem): JSX.Element => {
   return (
-    <div className="overflow-hidden transition-all border-2 rounded-lg w-80 hover:bg-slate-100 ">
+    <div className="mx-auto overflow-hidden transition-all border-2 rounded-lg w-80 hover:bg-slate-100">
       <a href={videoBaseUrl + id.videoId} target="_blank" rel="noreferrer">
         <div className="flex justify-center">
           <img

--- a/frontend/components/videos/YoutubeVideoList.tsx
+++ b/frontend/components/videos/YoutubeVideoList.tsx
@@ -1,12 +1,11 @@
 import YoutubeVideo from "components/videos/YoutubeVideo";
+import useClientWidth from "hooks/useClientWidth";
 import { IYoutubeSearchItem } from "interface/Youtube.interface";
 import { useBadmintonVideos } from "query/videos/videos";
-import { useEffect, useState } from "react";
 import Slider from "react-slick";
-import { debounce } from "utils/debounce";
 
 const setSlideToShow = (clientWidth: number) => {
-  if (clientWidth < 656) {
+  if (clientWidth <= 656) {
     return 1;
   } else if (clientWidth < 992) {
     return 2;
@@ -28,18 +27,7 @@ export const YoutubeVideoListView = ({
 }: {
   videoList: IYoutubeSearchItem[] | undefined;
 }) => {
-  const [clientWidth, setClientWidth] = useState(
-    document.documentElement.clientWidth,
-  );
-
-  const handleResize = () =>
-    setClientWidth(document.documentElement.clientWidth);
-
-  useEffect(() => {
-    addEventListener("resize", debounce(handleResize));
-
-    return removeEventListener("resize", () => {});
-  }, []);
+  const clientWidth = useClientWidth();
 
   const sliderOptions = {
     arrows: false,
@@ -47,10 +35,10 @@ export const YoutubeVideoListView = ({
     autoplay: true,
     autoplaySpeed: 2000,
   };
+
   return (
     <section>
       <p className="text-2xl font-bold">배드민턴 Youtube List</p>
-
       <Slider {...sliderOptions}>
         {videoList?.map((video) => (
           <YoutubeVideo key={video.id.videoId} {...video} />

--- a/frontend/components/videos/YoutubeVideoList.tsx
+++ b/frontend/components/videos/YoutubeVideoList.tsx
@@ -1,0 +1,61 @@
+import YoutubeVideo from "components/videos/YoutubeVideo";
+import { IYoutubeSearchItem } from "interface/Youtube.interface";
+import { useBadmintonVideos } from "query/videos/videos";
+import { useEffect, useState } from "react";
+import Slider from "react-slick";
+import { debounce } from "utils/debounce";
+
+const setSlideToShow = (clientWidth: number) => {
+  if (clientWidth < 656) {
+    return 1;
+  } else if (clientWidth < 992) {
+    return 2;
+  } else {
+    return 3;
+  }
+};
+
+const YoutubeVideoList = () => {
+  const { data: videoList } = useBadmintonVideos();
+
+  return <YoutubeVideoListView videoList={videoList} />;
+};
+
+export default YoutubeVideoList;
+
+export const YoutubeVideoListView = ({
+  videoList,
+}: {
+  videoList: IYoutubeSearchItem[] | undefined;
+}) => {
+  const [clientWidth, setClientWidth] = useState(
+    document.documentElement.clientWidth,
+  );
+
+  const handleResize = () =>
+    setClientWidth(document.documentElement.clientWidth);
+
+  useEffect(() => {
+    addEventListener("resize", debounce(handleResize));
+
+    return removeEventListener("resize", () => {});
+  }, []);
+
+  const sliderOptions = {
+    arrows: false,
+    slidesToShow: setSlideToShow(clientWidth),
+    autoplay: true,
+    autoplaySpeed: 2000,
+  };
+  return (
+    <section>
+      <p className="text-2xl font-bold">배드민턴 Youtube List</p>
+
+      <Slider {...sliderOptions}>
+        {videoList?.map((video) => (
+          <YoutubeVideo key={video.id.videoId} {...video} />
+        ))}
+      </Slider>
+    </section>
+  );
+};

--- a/frontend/hooks/useClientWidth.ts
+++ b/frontend/hooks/useClientWidth.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { debounce } from "utils/debounce";
+
+const useClientWidth = (): number => {
+  const [clientWidth, setClientWidth] = useState<number>(
+    document.documentElement.clientWidth,
+  );
+
+  const handleResize = () => {
+    setClientWidth(document.documentElement.clientWidth);
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", debounce(handleResize));
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return clientWidth;
+};
+export default useClientWidth;

--- a/frontend/interface/Youtube.interface.ts
+++ b/frontend/interface/Youtube.interface.ts
@@ -1,0 +1,45 @@
+export interface IYoutubeSearchResponse {
+  kind: string;
+  etag: string;
+  nextPageToken: string;
+  regionCode: string;
+  pageInfo: {
+    totalResults: number;
+    resultsPerPage: number;
+  };
+  items: IYoutubeSearchItem[];
+}
+
+export interface IYoutubeSearchItem {
+  kind: string;
+  etag: string;
+  id: {
+    kind: string;
+    videoId: string;
+  };
+  snippet: {
+    publishedAt: string;
+    channelId: string;
+    title: string;
+    description: string;
+    thumbnails: {
+      default: {
+        url: string;
+        width: number;
+        height: number;
+      };
+      medium: {
+        url: string;
+        width: number;
+        height: number;
+      };
+      high: {
+        url: string;
+        width: number;
+        height: number;
+      };
+    };
+    channelTitle: string;
+    liveBroadcastContent: string;
+  };
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -14,11 +14,20 @@ const MainRacketCarousel = dynamic(
   },
 );
 
+const YoutubeVideoList = dynamic(
+  () => import("components/videos/YoutubeVideoList"),
+  {
+    loading: () => <Spinner />,
+    ssr: false,
+  },
+);
+
 const Home: NextPage = () => {
   return (
     <div className="flex flex-col gap-y-5 border-red-900 max-w-[1200px] h-screen mx-auto p-4 ">
       <MainGreetingCarousel />
       <MainRacketCarousel />
+      <YoutubeVideoList />
     </div>
   );
 };

--- a/frontend/query/queryKeys.ts
+++ b/frontend/query/queryKeys.ts
@@ -6,7 +6,7 @@ export const queryKeys = Object.freeze({
   },
   rackets: {
     all: ["rackets"],
-    list: (brand: any, page: any) => ["rackets", "list", brand, { page }],
+    list: (brand: string, page: number) => ["rackets", "list", brand, { page }],
     single: (racketId: number) => [
       ...queryKeys.rackets.all,
       "single",
@@ -28,5 +28,9 @@ export const queryKeys = Object.freeze({
   statistics: {
     all: ["statistics"],
     single: (racketId: number) => [...queryKeys.statistics.all, racketId],
+  },
+
+  videos: {
+    all: ["videos"],
   },
 });

--- a/frontend/query/videos/videos.ts
+++ b/frontend/query/videos/videos.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import axios, { AxiosError } from "axios";
+import {
+  IYoutubeSearchItem,
+  IYoutubeSearchResponse,
+} from "interface/Youtube.interface";
+import { queryKeys } from "query/queryKeys";
+
+const getBadmintonVideos = async () => {
+  const { data } = await axios.get(
+    "https://www.googleapis.com/youtube/v3/search",
+    {
+      params: {
+        part: "snippet",
+        q: "배드민턴",
+        key: "AIzaSyC0nw1p8vBU-azAAwe6-XohDGxrMCjUDng",
+        maxResults: 10,
+      },
+    },
+  );
+  return data;
+};
+
+export const useBadmintonVideos = () => {
+  return useQuery<IYoutubeSearchResponse, AxiosError, IYoutubeSearchItem[]>(
+    queryKeys.videos.all,
+    getBadmintonVideos,
+    {
+      select: (data) => {
+        return data.items;
+      },
+    },
+  );
+};

--- a/frontend/query/videos/videos.ts
+++ b/frontend/query/videos/videos.ts
@@ -13,7 +13,7 @@ const getBadmintonVideos = async () => {
       params: {
         part: "snippet",
         q: "배드민턴",
-        key: "AIzaSyC0nw1p8vBU-azAAwe6-XohDGxrMCjUDng",
+        key: process.env.NEXT_PUBLIC_YOUTUBE_API_KEY,
         maxResults: 10,
       },
     },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,5 +22,5 @@
     "noEmitOnError": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "frontend"],
-  "exclude": ["node_modules", "**/**/*.stories.tsx", "**/**/*.test.tsx"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 설명

Yotube Data Api 를 이용하여, 배드민턴과 관련된 영상 리스트를 메인화면에 표시합니다.

## 관련 이슈

Fix #98 

## 변경사항

**FE**
- [x] youtube 비디오를 보여줄 컴포넌트 퍼블리싱
- [x] youtube api를 호출할 query 작성
- [x] Slick을 이용한 carousel 만들기
- [x] 자잘한 css 해결

## 스크린샷
![image](https://github.com/inkyu0103/badminton-app/assets/48270642/5b4c548e-42f2-46b9-9376-9c8c865ee7e0)
