### PR TITLE
fix: fix carousel css

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -7,7 +7,7 @@ const testRacket = () =>
     async (idx, _) =>
       await client.racket.create({
         data: {
-          id: 2,
+          id: idx + 10,
           name: `나노레이 ${idx + 1}`,
           rating: 5,
           image: null,

--- a/frontend/components/carousels/MainRacketCarousel.tsx
+++ b/frontend/components/carousels/MainRacketCarousel.tsx
@@ -31,6 +31,8 @@ const MainRacketCarouselView = ({
     verticalSwiping: clientWidth < 768,
     autoplay: true,
     autoplaySpeed: 2000,
+    variableWidth: clientWidth >= 768,
+    adaptiveHeight: clientWidth >= 768,
   };
 
   return (
@@ -39,7 +41,12 @@ const MainRacketCarouselView = ({
       <p className="text-xl font-bold">YONEX</p>
       <Slider {...sliderOptions}>
         {rackets.rackets.map((racket) => (
-          <Racket key={racket.id} name={racket.name} racketId={racket.id} />
+          <Racket
+            key={racket.id}
+            name={racket.name}
+            racketId={racket.id}
+            score={racket.score}
+          />
         ))}
       </Slider>
     </section>

--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -1,19 +1,28 @@
 /* eslint-disable @next/next/no-img-element */
 import { RacketProps } from "interface/Racket.interface";
 import Link from "next/link";
+import { Rating } from "react-simple-star-rating";
 
-const Racket = ({ name, racketId }: RacketProps) => (
+const Racket = ({ name, racketId, score }: RacketProps) => (
   <Link href={`/rackets/yonex/${racketId}?page=1`}>
-    <section className="flex items-center w-full h-32 p-2 mt-1 duration-300 ease-out rounded-md cursor-pointer drop-shadow-sm hover:bg-slate-100 gap-x-2 gap md:w-[300px] md:h-[300px] md:block">
-      <div className="justify-center md:flex">
+    <section className="my-2 md:my-0 border overflow-hidden flex w-full h-36  items-center md:w-[280px] md:h-auto md:block   duration-300 ease-out rounded-md cursor-pointer drop-shadow-sm hover:bg-slate-100">
+      <div>
         <img
-          className="rounded-md w-28 h-28 md:w-64 md:h-64"
+          className="rounded-md h-36 md:w-[280px] md:h-[280px]"
           alt="racket"
           src="https://m.woosungsports.com/web/product/big/412_5ff22e3f894ac8106c2773bec3fbe12c.jpg"
         />
       </div>
-      <div className="h-full md:h-auto">
+      <div className="h-full p-2">
         <p>{name}</p>
+        <Rating
+          size={20}
+          initialValue={score}
+          readonly
+          allowFraction
+          emptyStyle={{ display: "flex" }}
+          fillStyle={{ display: "-webkit-inline-box" }}
+        />
       </div>
     </section>
   </Link>

--- a/frontend/components/videos/YoutubeVideo.tsx
+++ b/frontend/components/videos/YoutubeVideo.tsx
@@ -5,7 +5,7 @@ const videoBaseUrl = "https://www.youtube.com/watch?v=";
 
 const YoutubeVideo = ({ snippet, id }: IYoutubeSearchItem): JSX.Element => {
   return (
-    <div className="mx-auto overflow-hidden transition-all border-2 rounded-lg w-80 hover:bg-slate-100">
+    <div className="mr-4 overflow-hidden transition-all border-2 rounded-lg md:mx-0 w-80 hover:bg-slate-100">
       <a href={videoBaseUrl + id.videoId} target="_blank" rel="noreferrer">
         <div className="flex justify-center">
           <img

--- a/frontend/components/videos/YoutubeVideoList.tsx
+++ b/frontend/components/videos/YoutubeVideoList.tsx
@@ -1,18 +1,7 @@
 import YoutubeVideo from "components/videos/YoutubeVideo";
-import useClientWidth from "hooks/useClientWidth";
 import { IYoutubeSearchItem } from "interface/Youtube.interface";
 import { useBadmintonVideos } from "query/videos/videos";
 import Slider from "react-slick";
-
-const setSlideToShow = (clientWidth: number) => {
-  if (clientWidth <= 656) {
-    return 1;
-  } else if (clientWidth < 992) {
-    return 2;
-  } else {
-    return 3;
-  }
-};
 
 const YoutubeVideoList = () => {
   const { data: videoList } = useBadmintonVideos();
@@ -27,13 +16,11 @@ export const YoutubeVideoListView = ({
 }: {
   videoList: IYoutubeSearchItem[] | undefined;
 }) => {
-  const clientWidth = useClientWidth();
-
   const sliderOptions = {
     arrows: false,
-    slidesToShow: setSlideToShow(clientWidth),
     autoplay: true,
     autoplaySpeed: 2000,
+    variableWidth: true,
   };
 
   return (

--- a/frontend/interface/Racket.interface.ts
+++ b/frontend/interface/Racket.interface.ts
@@ -1,6 +1,7 @@
 export interface RacketProps {
   name: string;
   racketId: number;
+  score: number;
 }
 
 export interface RacketResponse {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,7 @@
 import "styles/globals.css";
+import "styles/slick.css";
 
-import { QueryClient,QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import CheckLogin from "components/common/CheckLogin";
 import Header from "components/common/Header";

--- a/frontend/styles/slick.css
+++ b/frontend/styles/slick.css
@@ -1,0 +1,6 @@
+@media (min-width: 768px) {
+  .slick-track {
+    display: flex !important;
+    gap: 16px !important;
+  }
+}


### PR DESCRIPTION
## 설명

react-slick의 내부에 들어가는 요소들이 예상대로 렌더링 되지 않는 문제를 해결합니다.

## 관련 이슈

Fix #100 

## 변경사항

**`Racket` 컴포넌트 변경점**
- 컨테이너 너비가 변경되었습니다. (300px -> 280px)
  - 바뀐 이유는 최대 너비 1200px에서 4개의 컨텐츠가 들어가게 함 + padding 16px를 고려했기 때문입니다. 
  - (1200 - (16*5)) / 4 = 280

**`React-slick` 변경점**
- SliderOptions의 일부 옵션을 변경했습니다.
- 현재 Slider를 `index.tsx` 에서 3개를 사용하고 있습니다. 각 Slider마다 적용되어야 하는 내용이 달라, 불가피하게 각 컴포넌트에 따로 silderOptions을 만들어서 사용하고 있습니다.

**이전 문제점**
- 너비에 따라 `slideToShow` 를 지정해주면 항상 좌측 정렬되어 있는 문제가 있었습니다.
- 단순히 Racket 컴포넌트가 Carousel에만 사용되는 것이 아니라, 다른 곳에도 재사용되기 때문에, 컴포넌트 자체를 수정할 수는 없었습니다.
- react-slick에서는 별도로 option에 css를 overide 하는 방법을 제공하지 않습니다. 따라서 직접 css를 override를 해야합니다.
- css 우선순위 상의 문제로 override 하는 것도 원하는 대로 동작하지 않아 `!important` 키워드를 사용하여 문제를 해결하였습니다.

나머지 설명은 코드와 같이 설명합니다.







## 스크린샷
