### PR TITLE
refactor: advance to select the rank in statistics

### DIFF
--- a/backend/src/statistics/statistics.controller.ts
+++ b/backend/src/statistics/statistics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { StatisticsService } from 'statistics/statistics.service';
 import { StatisticsRank } from 'statistics/statistics.type';
 
@@ -9,7 +9,7 @@ export class StatisticsController {
   @Get('/:racketId')
   async getStatisticsByRacketId(
     @Param('racketId', ParseIntPipe) racketId: number,
-    @Param('rank') rank: StatisticsRank,
+    @Query('rank') rank: StatisticsRank,
   ) {
     return this.statisticsService.getStatisticsByRacketIdAndRank(
       racketId,

--- a/backend/src/statistics/statistics.controller.ts
+++ b/backend/src/statistics/statistics.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { StatisticsService } from 'statistics/statistics.service';
+import { StatisticsRank } from 'statistics/statistics.type';
 
 @Controller('statistics')
 export class StatisticsController {
@@ -8,7 +9,11 @@ export class StatisticsController {
   @Get('/:racketId')
   async getStatisticsByRacketId(
     @Param('racketId', ParseIntPipe) racketId: number,
+    @Param('rank') rank: StatisticsRank,
   ) {
-    return this.statisticsService.getStatisticsByRacketId(racketId);
+    return this.statisticsService.getStatisticsByRacketIdAndRank(
+      racketId,
+      rank,
+    );
   }
 }

--- a/backend/src/statistics/statistics.repository.ts
+++ b/backend/src/statistics/statistics.repository.ts
@@ -15,7 +15,7 @@ export class StatisticsRepository {
       },
 
       where: {
-        rank,
+        rank: rank === 'ALL' ? { in: ['S', 'A', 'B', 'C', 'D'] } : rank,
         Review: {
           some: {
             racketId,
@@ -49,10 +49,9 @@ export class StatisticsRepository {
   async getRacketControl(racketId: number, rank: StatisticsRank) {
     return this.prismaService.racketReview.count({
       where: {
-        racketId,
         control: 0,
         user: {
-          rank,
+          rank: rank === 'ALL' ? { in: ['S', 'A', 'B', 'C', 'D'] } : rank,
         },
       },
     });
@@ -64,7 +63,7 @@ export class StatisticsRepository {
         racketId,
         power: 0,
         user: {
-          rank,
+          rank: rank === 'ALL' ? { in: ['S', 'A', 'B', 'C', 'D'] } : rank,
         },
       },
     });
@@ -77,7 +76,7 @@ export class StatisticsRepository {
         // change constans or enum
         weight: 0 || 1,
         user: {
-          rank,
+          rank: rank === 'ALL' ? { in: ['S', 'A', 'B', 'C', 'D'] } : rank,
         },
       },
     });

--- a/backend/src/statistics/statistics.repository.ts
+++ b/backend/src/statistics/statistics.repository.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
 import { aggregateByField } from 'statistics/utils';
+import { StatisticsRank } from 'statistics/statistics.type';
 
 @Injectable()
 export class StatisticsRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getRacketUserGender(racketId: number) {
+  async getRacketUserGender(racketId: number, rank: StatisticsRank) {
     const result = await this.prismaService.user.groupBy({
       by: ['gender'],
       _count: {
@@ -14,6 +15,7 @@ export class StatisticsRepository {
       },
 
       where: {
+        rank,
         Review: {
           some: {
             racketId,
@@ -44,29 +46,39 @@ export class StatisticsRepository {
     return aggregateByField(result, 'rank');
   }
 
-  async getRacketControl(racketId: number) {
+  async getRacketControl(racketId: number, rank: StatisticsRank) {
     return this.prismaService.racketReview.count({
       where: {
         racketId,
         control: 0,
+        user: {
+          rank,
+        },
       },
     });
   }
 
-  async getRacketPower(racketId: number) {
+  async getRacketPower(racketId: number, rank: StatisticsRank) {
     return this.prismaService.racketReview.count({
       where: {
         racketId,
         power: 0,
+        user: {
+          rank,
+        },
       },
     });
   }
 
-  async getRacketWeight(racketId: number) {
+  async getRacketWeight(racketId: number, rank: StatisticsRank) {
     return this.prismaService.racketReview.count({
       where: {
         racketId,
+        // change constans or enum
         weight: 0 || 1,
+        user: {
+          rank,
+        },
       },
     });
   }

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -1,17 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { StatisticsRepository } from 'statistics/statistics.repository';
+import { StatisticsRank } from 'statistics/statistics.type';
 
 @Injectable()
 export class StatisticsService {
   constructor(private readonly statisticsRepository: StatisticsRepository) {}
 
-  async getStatisticsByRacketId(racketId: number) {
-    const control = await this.statisticsRepository.getRacketControl(racketId);
-    const power = await this.statisticsRepository.getRacketPower(racketId);
-    const weight = await this.statisticsRepository.getRacketWeight(racketId);
+  async getStatisticsByRacketIdAndRank(racketId: number, rank: StatisticsRank) {
+    const control = await this.statisticsRepository.getRacketControl(
+      racketId,
+      rank,
+    );
+    const power = await this.statisticsRepository.getRacketPower(
+      racketId,
+      rank,
+    );
+    const weight = await this.statisticsRepository.getRacketWeight(
+      racketId,
+      rank,
+    );
 
     const genders = await this.statisticsRepository.getRacketUserGender(
       racketId,
+      rank,
     );
 
     const ranks = await this.statisticsRepository.getRacketUserRank(racketId);

--- a/backend/src/statistics/statistics.type.ts
+++ b/backend/src/statistics/statistics.type.ts
@@ -1,0 +1,1 @@
+export type StatisticsRank = undefined | 'S' | 'A' | 'B' | 'C' | 'D';

--- a/backend/src/statistics/statistics.type.ts
+++ b/backend/src/statistics/statistics.type.ts
@@ -1,1 +1,1 @@
-export type StatisticsRank = undefined | 'S' | 'A' | 'B' | 'C' | 'D';
+export type StatisticsRank = 'ALL' | 'S' | 'A' | 'B' | 'C' | 'D';

--- a/frontend/components/rackets/RacketDetail.tsx
+++ b/frontend/components/rackets/RacketDetail.tsx
@@ -1,11 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
-import HalfPieChart from "components/charts/HalfPieChart";
-import SimpleBarChart from "components/charts/SimpleBarChart";
 import EvaluateButton from "components/common/EvaluateButton";
 import Modal from "components/common/Modal";
 import Pagination from "components/common/Pagination";
 import CreateReview from "components/rackets/CreateReview";
 import EditReview from "components/rackets/EditReview";
+import RacketStatistics from "components/rackets/RacketStatistics";
 import Review from "components/rackets/Review";
 import { formatDistanceToNow } from "date-fns";
 import { ko } from "date-fns/locale";
@@ -15,7 +14,6 @@ import {
   useDeleteRacketReviewMutation,
   useReviewList,
 } from "query/reviews/reviews";
-import { useReviewStatistics } from "query/reviews/statistics";
 import { Fragment, useState } from "react";
 import { Rating } from "react-simple-star-rating";
 import { useRecoilValue } from "recoil";
@@ -31,14 +29,14 @@ const MODAL_TYPE = Object.freeze({
 const isModalOpen = (value: null | string) => value !== null;
 
 const RacketDetail = () => {
-  const { data: racket } = useRacketQuery();
-  const { data: reviewList } = useReviewList();
-  const { data: reviewStatistics } = useReviewStatistics();
-
-  const user = useRecoilValue(userState);
   const [modalState, setModalState] = useState<null | string>(MODAL_TYPE.CLOSE);
   const [reviewId, setReviewId] = useState<null | number>(null);
+
+  const user = useRecoilValue(userState);
   const router = useRouter();
+
+  const { data: racket } = useRacketQuery();
+  const { data: reviewList } = useReviewList();
 
   const { mutate: deleteRacketReview } = useDeleteRacketReviewMutation();
 
@@ -76,23 +74,7 @@ const RacketDetail = () => {
           </section>
         </div>
 
-        <section className="mx-auto max-md:flex max-md:flex-col max-md:items-center">
-          <p className="my-4 text-2xl font-bold">라켓 데이터</p>
-          <div className="md:flex md:justify-between">
-            <HalfPieChart
-              data={reviewStatistics?.genders}
-              title="남녀 성별 비율"
-            />
-            <HalfPieChart
-              data={reviewStatistics?.ranks}
-              title="사용 급수 비율"
-            />
-            <SimpleBarChart
-              data={reviewStatistics?.criteria}
-              title="라켓 선택 이유"
-            />
-          </div>
-        </section>
+        <RacketStatistics />
 
         <section className="mx-auto">
           <p className="my-4 text-2xl font-bold">리뷰</p>

--- a/frontend/components/rackets/RacketStatistics.stories.tsx
+++ b/frontend/components/rackets/RacketStatistics.stories.tsx
@@ -1,0 +1,7 @@
+import { RacketStatisticsView } from "components/rackets/RacketStatistics";
+
+export default {
+  component: RacketStatisticsView,
+};
+
+export const Default = () => <RacketStatisticsView />;

--- a/frontend/components/rackets/RacketStatistics.stories.tsx
+++ b/frontend/components/rackets/RacketStatistics.stories.tsx
@@ -1,7 +1,22 @@
 import { RacketStatisticsView } from "components/rackets/RacketStatistics";
+import { IRacketStatisticsProps } from "interface/Statistics.interface";
 
 export default {
   component: RacketStatisticsView,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
-export const Default = () => <RacketStatisticsView />;
+export const Default = (args: IRacketStatisticsProps) => (
+  <RacketStatisticsView {...args} />
+);
+
+Default.args = {
+  reviewStatistics: undefined,
+  handleChangeRank: () => {},
+};
+
+Default.argTypes = {
+  handleChangeRank: { table: { disable: true } },
+};

--- a/frontend/components/rackets/RacketStatistics.tsx
+++ b/frontend/components/rackets/RacketStatistics.tsx
@@ -1,13 +1,14 @@
 import HalfPieChart from "components/charts/HalfPieChart";
 import SimpleBarChart from "components/charts/SimpleBarChart";
-import { Rank } from "interface/User.interface";
+import {
+  IRacketStatisticsProps,
+  StatisticsRank,
+} from "interface/Statistics.interface";
 import { useReviewStatistics } from "query/reviews/statistics";
 import React, { useState } from "react";
 
-type StatisticsRank = undefined | Rank;
-
 const RacketStatistics = () => {
-  const [rank, setRank] = useState<StatisticsRank>(undefined);
+  const [rank, setRank] = useState<StatisticsRank>("ALL");
   const { data: reviewStatistics } = useReviewStatistics(rank);
 
   const handleChangeRank = (value: StatisticsRank) => {
@@ -26,7 +27,7 @@ export default RacketStatistics;
 export const RacketStatisticsView = ({
   reviewStatistics,
   handleChangeRank,
-}) => {
+}: IRacketStatisticsProps) => {
   return (
     <section className="mx-auto max-md:flex max-md:flex-col max-md:items-center">
       <div className="flex items-center gap-2">
@@ -35,7 +36,7 @@ export const RacketStatisticsView = ({
           className="text-xl font-bold"
           onChange={(e) => handleChangeRank(e.target.value as StatisticsRank)}
         >
-          <option value={undefined}>전체</option>
+          <option value="ALL">전체</option>
           <option value="S">S조</option>
           <option value="A">A조</option>
           <option value="B">B조</option>

--- a/frontend/components/rackets/RacketStatistics.tsx
+++ b/frontend/components/rackets/RacketStatistics.tsx
@@ -1,0 +1,56 @@
+import HalfPieChart from "components/charts/HalfPieChart";
+import SimpleBarChart from "components/charts/SimpleBarChart";
+import { Rank } from "interface/User.interface";
+import { useReviewStatistics } from "query/reviews/statistics";
+import React, { useState } from "react";
+
+type StatisticsRank = undefined | Rank;
+
+const RacketStatistics = () => {
+  const [rank, setRank] = useState<StatisticsRank>(undefined);
+  const { data: reviewStatistics } = useReviewStatistics(rank);
+
+  const handleChangeRank = (value: StatisticsRank) => {
+    setRank(value);
+  };
+
+  return (
+    <RacketStatisticsView
+      reviewStatistics={reviewStatistics}
+      handleChangeRank={handleChangeRank}
+    />
+  );
+};
+export default RacketStatistics;
+
+export const RacketStatisticsView = ({
+  reviewStatistics,
+  handleChangeRank,
+}) => {
+  return (
+    <section className="mx-auto max-md:flex max-md:flex-col max-md:items-center">
+      <div className="flex items-center gap-2">
+        <p className="my-4 text-2xl font-bold">라켓 데이터</p>
+        <select
+          className="text-xl font-bold"
+          onChange={(e) => handleChangeRank(e.target.value as StatisticsRank)}
+        >
+          <option value={undefined}>전체</option>
+          <option value="S">S조</option>
+          <option value="A">A조</option>
+          <option value="B">B조</option>
+          <option value="C">C조</option>
+          <option value="D">D조</option>
+        </select>
+      </div>
+      <div className="md:flex md:justify-between">
+        <HalfPieChart data={reviewStatistics?.genders} title="남녀 성별 비율" />
+        <HalfPieChart data={reviewStatistics?.ranks} title="사용 급수 비율" />
+        <SimpleBarChart
+          data={reviewStatistics?.criteria}
+          title="라켓 선택 이유"
+        />
+      </div>
+    </section>
+  );
+};

--- a/frontend/interface/Statistics.interface.ts
+++ b/frontend/interface/Statistics.interface.ts
@@ -20,6 +20,7 @@ export interface IReviewStatisticsResponse {
 type gender = "남성" | "여성";
 type rank = "S조" | "A조" | "B조" | "C조" | "D조";
 type criteria = "컨트롤" | "파워" | "무게";
+export type StatisticsRank = "ALL" | "S" | "A" | "B" | "C" | "D";
 
 export interface ISelectedStatistics {
   name: gender | rank | criteria;
@@ -31,4 +32,9 @@ export interface IStatistics {
   criteria: ISelectedStatistics[];
   genders: ISelectedStatistics[];
   ranks: ISelectedStatistics[];
+}
+
+export interface IRacketStatisticsProps {
+  reviewStatistics: undefined | IStatistics;
+  handleChangeRank: (value: StatisticsRank) => void;
 }

--- a/frontend/interface/User.interface.ts
+++ b/frontend/interface/User.interface.ts
@@ -2,10 +2,13 @@ interface User {
   id: number;
   email: string;
   password: string;
-  rank: string;
+  rank: Rank;
   gender: "MALE" | "FEMALE";
   birthday: Date;
 }
+
+export type Rank = "S" | "A" | "B" | "C" | "D";
+
 export interface CreateUser extends Omit<User, "gender"> {
   passwordConfirm: string;
   gender: "남성" | "여성";

--- a/frontend/pages/rackets/[brand]/[racketId].tsx
+++ b/frontend/pages/rackets/[brand]/[racketId].tsx
@@ -8,7 +8,7 @@ const RacketDetail = dynamic(() => import("components/rackets/RacketDetail"), {
 });
 
 const Test = () => (
-  <div>
+  <div className="flex-1">
     <SSRSuspense fallback={<Spinner />}>
       <RacketDetail />
     </SSRSuspense>

--- a/frontend/query/queryKeys.ts
+++ b/frontend/query/queryKeys.ts
@@ -1,3 +1,5 @@
+import { StatisticsRank } from "interface/Statistics.interface";
+
 export const queryKeys = Object.freeze({
   auth: {
     all: ["auth"],
@@ -27,7 +29,11 @@ export const queryKeys = Object.freeze({
 
   statistics: {
     all: ["statistics"],
-    single: (racketId: number) => [...queryKeys.statistics.all, racketId],
+    single: (racketId: number, rank: StatisticsRank) => [
+      ...queryKeys.statistics.all,
+      racketId,
+      rank,
+    ],
   },
 
   videos: {

--- a/frontend/query/reviews/statistics.ts
+++ b/frontend/query/reviews/statistics.ts
@@ -3,8 +3,8 @@ import { AxiosError } from "axios";
 import {
   IReviewStatisticsResponse,
   IStatistics,
+  StatisticsRank,
 } from "interface/Statistics.interface";
-import { Rank } from "interface/User.interface";
 import { useRouter } from "next/router";
 import axios from "query/axios";
 import { queryKeys } from "query/queryKeys";
@@ -47,18 +47,22 @@ const colorMaper = {
   },
 };
 
-const getReviewStatistics = async (racketId: number) => {
-  const { data } = await axios(`/statistics/${racketId}`);
+const getReviewStatistics = async (racketId: number, rank: StatisticsRank) => {
+  const { data } = await axios(`/statistics/${racketId}`, {
+    params: {
+      rank,
+    },
+  });
   return data;
 };
 
-export const useReviewStatistics = (rank: undefined | Rank) => {
-  const router = useRouter(rank);
+export const useReviewStatistics = (rank: StatisticsRank) => {
+  const router = useRouter();
   const racketId = Number.parseInt(router.query.racketId as string);
 
   return useQuery<IReviewStatisticsResponse, AxiosError, IStatistics>(
-    queryKeys.statistics.single(racketId),
-    () => getReviewStatistics(racketId),
+    queryKeys.statistics.single(racketId, rank),
+    () => getReviewStatistics(racketId, rank),
     {
       suspense: true,
       enabled: Number.isNaN(racketId) === false,

--- a/frontend/query/reviews/statistics.ts
+++ b/frontend/query/reviews/statistics.ts
@@ -4,6 +4,7 @@ import {
   IReviewStatisticsResponse,
   IStatistics,
 } from "interface/Statistics.interface";
+import { Rank } from "interface/User.interface";
 import { useRouter } from "next/router";
 import axios from "query/axios";
 import { queryKeys } from "query/queryKeys";
@@ -51,8 +52,8 @@ const getReviewStatistics = async (racketId: number) => {
   return data;
 };
 
-export const useReviewStatistics = () => {
-  const router = useRouter();
+export const useReviewStatistics = (rank: undefined | Rank) => {
+  const router = useRouter(rank);
   const racketId = Number.parseInt(router.query.racketId as string);
 
   return useQuery<IReviewStatisticsResponse, AxiosError, IStatistics>(


### PR DESCRIPTION
## 설명

급수에 따른 라켓 통계 데이터를 보여주도록 변경합니다.

## 관련 이슈

Fix #108 

## 변경사항

**BE** 
statistics의 controller / service / repository에서 FE에서 보내는 rank를 받을 수 있도록 인자가 추가되었습니다.

rank는 Query Parameter로 받습니다.

**FE**

1. 컴포넌트 분리

`RacketDetail` 컴포넌트는 내용상 3가지 section으로 이루어져 있었습니다.
- 라켓 정보
- 라켓 통계 데이터
- 라켓 리뷰

위 세가지 section은 서로 다른 query를 호출하고 있고, 상태와 관련된 변수를 공유하고 있지 않기 때문에, 분리해도 좋다고 판단하였습니다.

따라서 해당 PR에서는 라켓 통계 데이터를 우선적으로 분리합니다.

분리함으로서 기대할 수 있는 내용은 다음과 같습니다.
- 가독성
- 한 컴포넌트는 하나의 관심사를 가지게 됨
- UI 테스트 용이성
   - 뷰 내부에 로직이 담기지 않은 컴포넌트는 뷰 컴포넌트와 로직 컴포넌트로 분리하여 UI 테스트가 가능하게 됩니다.

2. api 변동
api로 전달하는 인자가 추가되었습니다. (rank)

통계를 이용할 때 사용되는 Rank의 값은 다음과 같습니다.
- ALL
- S
- A
- B
- C
- D

## 보완할 점
- rank를 변경할 때 깜빡임이 발생합니다. 
   - 해당 문제는 Suspense의 Fallback에 의해 발생하는 문제이며, 크리티컬한 이슈가 아니므로, 이슈로 등록하고 추후 처리하도록 합니다. ( #110 )

- { in : ['S', 'A', 'B', 'C', 'D' ] } 에서는 에러가 발생하지 않는데, 배열을 선언하는 경우 type error가 발생합니다. ( #111 )

## 스크린샷
