### PR TITLE
chore: use env file for baseUrl

### DIFF
--- a/frontend/query/axios.ts
+++ b/frontend/query/axios.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = "http://localhost:8000";
+const baseURL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export default axios.create({
   baseURL,


### PR DESCRIPTION
## 설명

하드코딩된 baseUrl 주소를 환경변수를 사용하도록 합니다.

## 관련 이슈

Fix #112 

## 변경사항

환경변수를 사용하는 것을 제외하고는 없습니다.

## 스크린샷

없습니다.