### PR TITLE
feat: enhance accessibility

### DIFF
--- a/frontend/components/common/Footer.tsx
+++ b/frontend/components/common/Footer.tsx
@@ -7,10 +7,14 @@ const Footer = () => {
     <footer className="flex justify-between w-full px-4 py-10 bg-black">
       <p className="text-xl font-semibold text-white">모두의 배드민턴</p>
       <div className="flex gap-x-1">
-        <Link target="_blank" href="https://github.com/inkyu0103">
+        <Link
+          target="_blank"
+          href="https://github.com/inkyu0103"
+          aria-label="developer's github"
+        >
           <GithubIcon />
         </Link>
-        <Link href="mailto:inkyu0103@gmail.com">
+        <Link href="mailto:inkyu0103@gmail.com" aria-label="developer's email">
           <MailIcon />
         </Link>
       </div>

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Head, Html, Main, NextScript } from "next/document";
 
 const Document = () => {
   return (
-    <Html>
+    <Html lang="ko">
       <Head>
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/frontend/pages/emailVerify.tsx
+++ b/frontend/pages/emailVerify.tsx
@@ -1,8 +1,12 @@
 import EmailVerify from "components/forms/EmailVerifyForms";
 import { NextPage } from "next";
+import Head from "next/head";
 
 const Signup: NextPage = () => (
   <div className="flex items-center justify-center h-screen">
+    <Head>
+      <title>이메일 인증</title>
+    </Head>
     <EmailVerify />
   </div>
 );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -5,6 +5,7 @@ import MainGreetingCarousel from "components/carousels/MainGreetingCarousel";
 import Spinner from "components/common/Spinner";
 import type { NextPage } from "next";
 import dynamic from "next/dynamic";
+import Head from "next/head";
 
 const MainRacketCarousel = dynamic(
   () => import("components/carousels/MainRacketCarousel"),
@@ -25,6 +26,9 @@ const YoutubeVideoList = dynamic(
 const Home: NextPage = () => {
   return (
     <div className="w-full flex-1 flex flex-col gap-y-5  max-w-[1200px]  mx-auto p-4 ">
+      <Head>
+        <title>모두의 배드민턴</title>
+      </Head>
       <MainGreetingCarousel />
       <MainRacketCarousel />
       <YoutubeVideoList />

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,9 +1,13 @@
 import LoginForms from "components/forms/LoginForms";
 import { NextPage } from "next";
+import Head from "next/head";
 import { OnlyPublicRoute } from "utils/conditionalRoutes";
 
 const Login: NextPage = () => (
   <div className="h-screen">
+    <Head>
+      <title>로그인</title>
+    </Head>
     <LoginForms />
   </div>
 );

--- a/frontend/pages/rackets/[brand]/[racketId].tsx
+++ b/frontend/pages/rackets/[brand]/[racketId].tsx
@@ -1,6 +1,7 @@
 import Spinner from "components/common/Spinner";
 import SSRSuspense from "components/common/SSRSuspense";
 import dynamic from "next/dynamic";
+import Head from "next/head";
 
 const RacketDetail = dynamic(() => import("components/rackets/RacketDetail"), {
   loading: () => <Spinner />,
@@ -9,6 +10,9 @@ const RacketDetail = dynamic(() => import("components/rackets/RacketDetail"), {
 
 const Test = () => (
   <div className="flex-1">
+    <Head>
+      <title>라켓 상세보기</title>
+    </Head>
     <SSRSuspense fallback={<Spinner />}>
       <RacketDetail />
     </SSRSuspense>

--- a/frontend/pages/rackets/[brand]/index.tsx
+++ b/frontend/pages/rackets/[brand]/index.tsx
@@ -2,10 +2,14 @@ import CheckMounted from "components/common/CheckMounted";
 import Spinner from "components/common/Spinner";
 import SSRSuspense from "components/common/SSRSuspense";
 import RacketList from "components/rackets/RacketList";
+import Head from "next/head";
 
 const RacketListWithBrand = () => {
   return (
     <SSRSuspense fallback={<Spinner />}>
+      <Head>
+        <title>라켓 리스트</title>
+      </Head>
       <CheckMounted>
         <RacketList />
       </CheckMounted>

--- a/frontend/pages/signup.tsx
+++ b/frontend/pages/signup.tsx
@@ -1,6 +1,7 @@
 import BadRequest from "components/common/BadRequest";
 import Spinner from "components/common/Spinner";
 import dynamic from "next/dynamic";
+import Head from "next/head";
 import React from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { OnlyPublicRoute } from "utils/conditionalRoutes";
@@ -12,6 +13,9 @@ const SignupForms = dynamic(() => import("components/forms/SignupForms"), {
 
 const Signup = () => (
   <ErrorBoundary fallback={<BadRequest />}>
+    <Head>
+      <title>회원가입</title>
+    </Head>
     <SignupForms />
   </ErrorBoundary>
 );


### PR DESCRIPTION
## 설명

Lighthouse의 접근성 지표를 개선합니다.

## 관련 이슈

Fix #114 

## 변경사항

- [x] <title> 요소 추가
- [x]  링크에 인식 가능한 이름 포함
- [x]  다국어화 및 현지화 설정


## 스크린샷
![image](https://github.com/inkyu0103/badminton-app/assets/48270642/1bca497a-d147-4791-ae40-6e0e6ad7f391)

## 추가적인 개선점

1. react-slick에서 발생하는 `aria-hidden: true`

![image](https://github.com/inkyu0103/badminton-app/assets/48270642/768d0f32-237f-434e-991d-bdce4cdbaa9e)

위 스크린샷에서 볼 수 있듯이 포커스 할 수 있는 하위요소가 있는 경우에 aria-hidden을 하게 되면 상호작용을 막는 것 때문에 접근성을 떨어뜨리는 문제가 발생한다고 나와있다.

라이브러리 자체에서 aria-hidden을 true로 설정해 놓은건데 어떻게 바꿔야 하나 싶다.

2. 맞춤 title을 제공하는 방법

`page` 폴더에 있는 파일마다 title을 달아주었다.
문제는 title을 달 때 구체적인 내용을 입력해주어야 하는데, 지금 구조는 page는 모두 컴포넌트의 조합들로 추상화 되어있다.

예를 들어 라켓 페이지를 보자.
```javascript
<div className="flex-1">
    <Head>
      <title>라켓 상세보기</title> // {라켓이름} 상세보기로 바꾸면 더 자세한 내용을 제공할 수 있다.
    </Head>
    <SSRSuspense fallback={<Spinner />}>
      <RacketDetail />
    </SSRSuspense>
  </div>
```
위와 같은 구조여서 해당 라켓의 이름이라던가, 디테일한 내용들을 title에 적어줄 수 없는 문제가 발생한다.

1. 구조를 바꾼다.
   - 이 목적을 달성하기 위해 추상화를 깨고 싶지는 않다. 컴포넌트의 응집성과 독립성을 고려할 때 현재 상태를 유지하는 것이 좋아보인다.

2. SSR을 사용한다.
   - nextjs의 서버 단에서 필요한 데이터를 불러와서 title에 주입하는 방법이 있겠다.
   - 문제는, 해당 라켓 정보를 불러오는 api를 서버단에서 부르고, RacketDetail 컴포넌트 내부에서 또 라켓정보를 부르게 되어 같은 정보를 이중으로 부르는 문제가 있다.
   - 위 문제는 실제로 지표를 측정해서 얼마나 유의미한 차이가 있는지 확인 해봐야한다.



