### PR TITLE
feat: add fixture data

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "cross-env NODE_ENV=prod node dist/main ",
     "seed:dev": "dotenv -e .env.local npx ts-node ./prisma/seed.ts",
+    "seed:staging":"dotenv -e .env.staging npx ts-node ./prisma/seed.ts",
     "lint": "eslint ./src --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -26,7 +26,6 @@ model User {
 model Racket {
   id      Int            @id @default(autoincrement())
   name    String         @unique
-  rating  Float
   price   Int
   image   String?
   shaft   Shaft

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,26 +1,42 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Racket } from '@prisma/client';
 
 const client = new PrismaClient();
 
-const testRacket = () =>
-  [...Array(20).keys()].map(
-    async (idx, _) =>
-      await client.racket.create({
-        data: {
-          id: idx + 10,
-          name: `나노레이 ${idx + 1}`,
-          image: null,
-          price: 10000,
-          shaft: 'FLEXIBLE',
-          weight: 'W3U',
-          score: 5,
-          brandId: 1,
-        },
-      }),
-  );
+const testRackets: Racket[] = new Array(20).fill(0).map((_, idx) => ({
+  id: idx + 10,
+  name: `나노레이 ${idx + 1}`,
+  image: null,
+  price: 10000,
+  shaft: 'FLEXIBLE',
+  weight: 'W3U',
+  score: 0,
+  brandId: 1,
+}));
+
+const makeTestBrand = () => {
+  return client.brand.create({
+    data: {
+      id: 1,
+      name: 'yonex',
+    },
+  });
+};
+
+const makeTestRackets = () => {
+  return client.racket.createMany({
+    data: testRackets,
+  });
+};
 
 const main = async () => {
-  Promise.all(testRacket());
+  console.time('⏰ total elapsed time');
+  console.log('💾 Setup test data...');
+  await makeTestBrand();
+  console.log('✅ complete makeTestBrand');
+  await makeTestRackets();
+  console.log('✅ complete makeTestRackets');
+
+  console.timeEnd('⏰ total elapsed time');
 };
 
 main()

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,6 +1,9 @@
-import { PrismaClient, Racket } from '@prisma/client';
+import { PrismaClient, Racket, RacketReview, User } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
 
 const client = new PrismaClient();
+
+const testRanks = ['S', 'A', 'B', 'C', 'D', 'E'] as const;
 
 const testRackets: Racket[] = new Array(20).fill(0).map((_, idx) => ({
   id: idx + 10,
@@ -11,6 +14,31 @@ const testRackets: Racket[] = new Array(20).fill(0).map((_, idx) => ({
   weight: 'W3U',
   score: 0,
   brandId: 1,
+}));
+
+const testUsers: User[] = new Array(20).fill(0).map((_, idx) => ({
+  id: idx,
+  nickname: `testUser ${idx}`,
+  email: `testUser${idx}@test.com`,
+  password: bcrypt.hashSync('testpassword', 10),
+  birthday: new Date('1995-01-01'),
+  gender: idx % 2 ? 'MALE' : 'FEMALE',
+  rank: testRanks[idx % 6],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}));
+
+const testReviews: RacketReview[] = new Array(20).fill(0).map((_, idx) => ({
+  id: idx + 20,
+  control: Math.round(Math.random()),
+  power: Math.round(Math.random()),
+  weight: Math.floor(Math.random() * 3),
+  racketId: 11,
+  review: `${idx} 번 째 테스트 리뷰입니다. 라켓에 대한 정보는 따로 없습니다.`,
+  userId: idx,
+  starRating: Math.floor(Math.random() * 6),
+  createdAt: new Date(),
+  updatedAt: new Date(),
 }));
 
 const makeTestBrand = () => {
@@ -28,6 +56,18 @@ const makeTestRackets = () => {
   });
 };
 
+const makeTestUsers = () => {
+  return client.user.createMany({
+    data: testUsers,
+  });
+};
+
+const makeTestReviews = () => {
+  return client.racketReview.createMany({
+    data: testReviews,
+  });
+};
+
 const main = async () => {
   console.time('⏰ total elapsed time');
   console.log('💾 Setup test data...');
@@ -35,6 +75,10 @@ const main = async () => {
   console.log('✅ complete makeTestBrand');
   await makeTestRackets();
   console.log('✅ complete makeTestRackets');
+  await makeTestUsers();
+  console.log('✅ complete makeTestUsers');
+  await makeTestReviews();
+  console.log('✅ complete makeTestReviews');
 
   console.timeEnd('⏰ total elapsed time');
 };

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -7,4 +7,5 @@
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }
+  // "setupFilesAfterEnv": ["./setupTest.ts"]
 }

--- a/backend/test/reviews.e2e-spec.ts
+++ b/backend/test/reviews.e2e-spec.ts
@@ -1,38 +1,17 @@
-import * as dotenv from 'dotenv';
 import * as request from 'supertest';
 import { Test } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { ReviewsModule } from 'reviews/reviews.module';
 import { PrismaModule } from 'prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
-import { execSync } from 'child_process';
-import { PrismaClient } from '@prisma/client';
-
-dotenv.config({
-  path: '.env.test',
-});
 
 describe('리뷰와 관련된 E2E 테스트를 진행합니다.', () => {
-  jest.setTimeout(10000);
   let app: INestApplication;
-  const prismaClient = new PrismaClient({
-    datasources: {
-      db: {
-        url: process.env.DATABASE_URL,
-      },
-    },
-  });
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [ConfigModule, ReviewsModule, PrismaModule],
     }).compile();
-
-    execSync('npx prisma db push', {
-      env: {
-        ...process.env,
-      },
-    });
 
     app = moduleRef.createNestApplication();
     await app.init();
@@ -40,20 +19,6 @@ describe('리뷰와 관련된 E2E 테스트를 진행합니다.', () => {
 
   afterAll(async () => {
     await app.close();
-
-    await prismaClient.$disconnect();
-
-    await prismaClient
-      .$executeRawUnsafe('DROP SCHEMA  testmobae CASCADE')
-      .then(() => {
-        console.log('test db의 스키마를 삭제하였습니다.');
-      });
-
-    await prismaClient
-      .$executeRawUnsafe('CREATE SCHEMA  testmobae ')
-      .then(() => {
-        console.log('test db의 스키마를 생성하였습니다..');
-      });
   });
 
   it('GET /reviews/:reviewId', () => {

--- a/backend/test/setupTest.ts
+++ b/backend/test/setupTest.ts
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process';
+import * as dotenv from 'dotenv';
+
+dotenv.config({
+  path: '.env.test',
+});
+
+beforeAll(async () => {
+  console.log('test db를 생성합니다.');
+  execSync('npx prisma db push', {
+    env: {
+      ...process.env,
+    },
+  });
+  console.log('test db를 생성 완료!');
+});
+
+afterAll(async () => {
+  execSync('npx prisma db drop', {
+    env: {
+      ...process.env,
+    },
+  });
+});


### PR DESCRIPTION
## 설명

초기 데이터 세팅을 위한 스크립트를 작성합니다.

초기 생성 데이터는 다음과 같습니다.

- 브랜드 
- 라켓
- 유저 데이터
- 리뷰 데이터


## 관련 이슈

Fix #120 

## 변경사항

- seed를 위해 prisma/seed.ts 를 제외하고 소스코드의 변화는 없습니다.
- staging 환경에서 동작할 seed command를 추가하였습니다.


## 스크린샷

스테이징 환경의 화면입니다.
![staging-mobae vercel app_rackets_yonex_11_page=1](https://github.com/inkyu0103/badminton-app/assets/48270642/c7c4d273-9b93-4685-9890-875df7487daf)

