### PR TITLE
refactor: add login error handling

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1725,6 +1725,14 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0"
       }
     },
+    "node_modules/@nestjs/jwt/node_modules/@types/jsonwebtoken": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@nestjs/mapped-types": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.2.2.tgz",
@@ -2290,9 +2298,10 @@
       "dev": true
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
-      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -11147,9 +11156,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
       "dependencies": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"
@@ -12966,6 +12975,16 @@
       "requires": {
         "@types/jsonwebtoken": "9.0.1",
         "jsonwebtoken": "9.0.0"
+      },
+      "dependencies": {
+        "@types/jsonwebtoken": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+          "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+          "requires": {
+            "@types/node": "*"
+          }
+        }
       }
     },
     "@nestjs/mapped-types": {
@@ -13408,9 +13427,10 @@
       "dev": true
     },
     "@types/jsonwebtoken": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
-      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -20242,9 +20262,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.19",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
+      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -89,8 +89,6 @@ export class AuthService {
   validateRefreshToken(refreshToken) {
     const result = this.jwtService.verify(refreshToken);
 
-    if (!result) throw new UnauthorizedException();
-
     const payload = {
       email: result.email,
       id: result.id,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { MailerService } from '@nestjs-modules/mailer/dist';
+import { MailerService } from '@nestjs-modules/mailer';
 import { AuthRepository } from 'auth/auth.repository';
 import { JwtService } from '@nestjs/jwt';
 import { User } from 'auth/types/auth.interface';

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,91 @@
+import * as cookieParser from 'cookie-parser';
+import * as request from 'supertest';
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AuthModule } from 'auth/auth.module';
+import { MailerModule } from '@nestjs-modules/mailer';
+import { PrismaModule } from 'prisma/prisma.module';
+import { EjsAdapter } from '@nestjs-modules/mailer/dist/adapters/ejs.adapter';
+
+describe('auth와 관련된 E2E 테스트를 진행합니다.', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        PrismaModule,
+        AuthModule,
+        MailerModule.forRootAsync({
+          useFactory: () => ({
+            transport: {
+              host: 'smtp.naver.com',
+              port: 587,
+              auth: {
+                user: process.env.SMTP_HOST_EMAIL,
+                pass: process.env.SMTP_HOST_PASSWORD,
+              },
+            },
+            defaults: {
+              from: '"no-reply" <email address>',
+            },
+            preview: false,
+            template: {
+              dir: __dirname + '/templates',
+              adapter: new EjsAdapter(),
+              options: {
+                strict: true,
+              },
+            },
+          }),
+        }),
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+
+    app.use(cookieParser());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /auth/signup', () => {
+    return request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({
+        email: 'mobae@test.com',
+        password: 'testpassword',
+        birthday: new Date().toISOString(),
+        rank: 'A',
+        gender: 'MALE',
+        nickname: '닉네임',
+      })
+      .expect(201);
+  });
+
+  it('POST /auth/login', () => {
+    return request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: 'mobae@test.com',
+        password: 'testpassword',
+      })
+      .expect(200);
+  });
+
+  it('GET /auth/validate-token', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'mobae@test.com', password: 'testpassword' });
+
+    const { header } = response;
+
+    return request(app.getHttpServer())
+      .get('/auth/validate-token')
+      .set('Cookie', [...header['set-cookie']])
+      .expect(200);
+  });
+});

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -6,6 +6,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
-  // "setupFilesAfterEnv": ["./setupTest.ts"]
+  },
+  "globalSetup": "./setup.ts",
+  "globalTeardown": "./teardown.ts",
+  "verbose": true
 }

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -5,20 +5,12 @@ dotenv.config({
   path: '.env.test',
 });
 
-beforeAll(async () => {
+module.exports = async function () {
   console.log('test db를 생성합니다.');
   execSync('npx prisma db push', {
     env: {
       ...process.env,
     },
   });
-  console.log('test db를 생성 완료!');
-});
-
-afterAll(async () => {
-  execSync('npx prisma db drop', {
-    env: {
-      ...process.env,
-    },
-  });
-});
+  console.log('test db 생성 완료!');
+};

--- a/backend/test/teardown.ts
+++ b/backend/test/teardown.ts
@@ -1,0 +1,17 @@
+import { execSync } from 'child_process';
+import * as dotenv from 'dotenv';
+
+dotenv.config({
+  path: '.env.test',
+});
+
+module.exports = async function () {
+  console.log('사용된 db를 정리합니다.');
+
+  execSync('npx prisma migrate reset --force', {
+    env: {
+      ...process.env,
+    },
+  });
+  console.log('사용된 db 정리를 완료했습니다.');
+};


### PR DESCRIPTION
## 설명

로그인 시 발생할 수 있는 에러를 처리합니다.

특히 토큰 관련하여 401 에러를 throw 하는 경우가 많은데, 에러 이유를 명확하게 하는 message를 담아주도록 변경합니다.

그리고 가능하다면 테스트도 작성해봅니다 😄 

#131 도 이어서 진행합니다

## 관련 이슈

Fix #136 

## 변경사항

현재 accessToken은 메모리에,  refresh token은 cookie에 저장하는 방식을 선택하고 있습니다.
refreshToken이 만료된 경우에는 cookie를 삭제하고 401 error를 던지도록 변경하였습니다.

try~catch 문을 service단이 아닌, controller 단에 적용하여 catch한 error의 유형에 따라 다른 응답을 반환할 수 있도록 바꾸었습니다. ~~(물론 지금은 Expire밖에 없지만요)~~

~~그리고 말많고 탈많던 테스트도 추가했습니다 🥳~~


## 스크린샷
없습니다.
