### PR TITLE
fix: change racket images

### DIFF
--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -12,7 +12,7 @@ const Racket = ({ name, racketId, score }: RacketProps) => (
           quality={80}
           width={280}
           height={280}
-          className="rounded-md h-36 md:w-[280px] md:h-[280px]"
+          className="rounded-md w-36 h-36 md:w-[280px] md:h-[280px]"
           alt="racket"
           src="https://staging-mobae-image.s3.ap-northeast-2.amazonaws.com/racket.png"
         />

--- a/frontend/components/rackets/Racket.tsx
+++ b/frontend/components/rackets/Racket.tsx
@@ -6,7 +6,7 @@ import { Rating } from "react-simple-star-rating";
 
 const Racket = ({ name, racketId, score }: RacketProps) => (
   <Link href={`/rackets/yonex/${racketId}?page=1`}>
-    <section className="my-2 md:my-0 border overflow-hidden flex w-full h-36  items-center md:w-[280px] md:h-auto md:block   duration-300 ease-out rounded-md cursor-pointer drop-shadow-sm hover:bg-slate-100">
+    <section className="my-2  border flex w-full h-36 items-center md:w-[280px] md:h-auto md:block  duration-300 ease-out rounded-md cursor-pointer drop-shadow-sm hover:bg-slate-100">
       <div>
         <Image
           quality={80}

--- a/frontend/components/rackets/RacketList.tsx
+++ b/frontend/components/rackets/RacketList.tsx
@@ -51,7 +51,7 @@ const RacketList = () => {
 export default RacketList;
 
 export const RacketListView = ({
-  brand = "yonex",
+  brand = "Yonex",
   data,
   curPage,
 }: RacketListViewProps) => {
@@ -69,8 +69,8 @@ export const RacketListView = ({
   }, []);
 
   return (
-    <div className="flex flex-col  max-w-[1200px] mx-auto  ">
-      <h1 className="my-4 text-3xl font-bold">{brand}</h1>
+    <div className="flex flex-col max-w-[1200px] mx-auto p-4">
+      <h1 className="text-3xl font-bold">{brand}</h1>
       <div
         className={`md:grid  md:gap-4 md:mx-auto  ${setColNumber(clientWidth)}`}
       >

--- a/frontend/components/rackets/RacketSpec.tsx
+++ b/frontend/components/rackets/RacketSpec.tsx
@@ -41,7 +41,7 @@ const RacketSpec = ({ score, weight, balance, shaft }: RacketSpecProps) => {
           width={328}
           height={328}
           alt="racket"
-          src="https://staging-mobae-image.s3.ap-northeast-2.amazonaws.com/racket.jpg"
+          src="https://staging-mobae-image.s3.ap-northeast-2.amazonaws.com/racket.png"
           className="mx-auto "
         />
       </div>


### PR DESCRIPTION
## 설명

- 라켓 이미지 저작권 문제로, 무료 이미지를 사용합니다.
- 특정 해상도 범위 내에서 이미지가 깨지는 문제를 해결합니다.

## 관련 이슈

Fix #140 

## 변경사항

코드에서 변경되는 부분은 없습니다. 불필요한 css 특성만 제거하는 PR입니다.

## 스크린샷

**PC**
![image](https://github.com/inkyu0103/badminton-app/assets/48270642/a73cb780-9e82-4c29-97d0-ac09ef47ab85)

**모바일**
![image](https://github.com/inkyu0103/badminton-app/assets/48270642/c435b585-ead4-4dda-80dc-5b26e1e4e7cb)

