### PR TITLE
fix: correct missing statistics

### DIFF
--- a/frontend/__tests__/RacketStatistics.test.tsx
+++ b/frontend/__tests__/RacketStatistics.test.tsx
@@ -1,0 +1,24 @@
+import "@testing-library/jest-dom/extend-expect";
+
+import { render } from "@testing-library/react";
+import { RacketStatisticsView } from "components/rackets/RacketStatistics";
+import { IStatistics } from "interface/Statistics.interface";
+
+const emptyReviewStatistics: IStatistics = {
+  criteria: [],
+  genders: [],
+  ranks: [],
+};
+
+describe("라켓 통계와 관련된 테스트를 수행합니다. ", () => {
+  it("라켓 통계가 없는 경우, 사용자에게 통계 내용이 없다는 메시지를 렌더링합니다.", () => {
+    const screen = render(
+      <RacketStatisticsView
+        isEmpty
+        handleChangeRank={() => {}}
+        reviewStatistics={emptyReviewStatistics}
+      />,
+    );
+    expect(screen.getByTestId("empty statistics message")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/rackets/RacketStatistics.tsx
+++ b/frontend/components/rackets/RacketStatistics.tsx
@@ -10,6 +10,7 @@ import React, { useState } from "react";
 const RacketStatistics = () => {
   const [rank, setRank] = useState<StatisticsRank>("ALL");
   const { data: reviewStatistics } = useReviewStatistics(rank);
+  const isEmpty = reviewStatistics?.genders.length === 0;
 
   const handleChangeRank = (value: StatisticsRank) => {
     setRank(value);
@@ -17,6 +18,7 @@ const RacketStatistics = () => {
 
   return (
     <RacketStatisticsView
+      isEmpty={isEmpty}
       reviewStatistics={reviewStatistics}
       handleChangeRank={handleChangeRank}
     />
@@ -25,6 +27,7 @@ const RacketStatistics = () => {
 export default RacketStatistics;
 
 export const RacketStatisticsView = ({
+  isEmpty = false,
   reviewStatistics,
   handleChangeRank,
 }: IRacketStatisticsProps) => {
@@ -44,14 +47,26 @@ export const RacketStatisticsView = ({
           <option value="D">D조</option>
         </select>
       </div>
-      <div className="md:flex md:justify-between">
-        <HalfPieChart data={reviewStatistics?.genders} title="남녀 성별 비율" />
-        <HalfPieChart data={reviewStatistics?.ranks} title="사용 급수 비율" />
-        <SimpleBarChart
-          data={reviewStatistics?.criteria}
-          title="라켓 선택 이유"
-        />
-      </div>
+
+      {isEmpty ? (
+        <div className="flex justify-center p-4">
+          <p data-testid="empty statistics message" className="text-xl">
+            조건에 맞는 통계 결과가 없습니다.
+          </p>
+        </div>
+      ) : (
+        <div className="md:flex md:justify-between">
+          <HalfPieChart
+            data={reviewStatistics?.genders}
+            title="남녀 성별 비율"
+          />
+          <HalfPieChart data={reviewStatistics?.ranks} title="사용 급수 비율" />
+          <SimpleBarChart
+            data={reviewStatistics?.criteria}
+            title="라켓 선택 이유"
+          />
+        </div>
+      )}
     </section>
   );
 };

--- a/frontend/interface/Statistics.interface.ts
+++ b/frontend/interface/Statistics.interface.ts
@@ -35,6 +35,7 @@ export interface IStatistics {
 }
 
 export interface IRacketStatisticsProps {
+  isEmpty: boolean;
   reviewStatistics: undefined | IStatistics;
   handleChangeRank: (value: StatisticsRank) => void;
 }


### PR DESCRIPTION
## 설명

라켓 통계 부분에서 다음 문제를 해결합니다.
- [x] 통계 자료가 없는 경우, 빈 통계 차트 대신 사용자에게 알림 문구 넣기
- [x] 누락된 통계 관련 타입 설정
- [x] 테스트 작성해보기

## 관련 이슈

Fix #148 

## 변경사항

코드적으로 변경되는 부분을 작성해주세요


## 스크린샷
