### PR TITLE
feat: add user club model

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,6 +7,27 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Club {
+  id        String     @id @default(uuid())
+  name      String
+  createAt  DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt() @map("updated_at")
+  UserClub  UserClub[]
+
+  @@map("club")
+}
+
+model UserClub {
+  id     String   @id @default(uuid())
+  userId Int
+  clubId String
+  user   User     @relation(references: [id], fields: [userId])
+  club   Club     @relation(references: [id], fields: [clubId])
+  role   ClubRole @default(MEMBER)
+
+  @@map("user_club")
+}
+
 model User {
   id        Int      @id @default(autoincrement())
   nickname  String   @unique
@@ -18,7 +39,8 @@ model User {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt() @map("updated_at")
 
-  Review RacketReview[]
+  Review   RacketReview[]
+  UserClub UserClub[]
 
   @@map("user")
 }
@@ -102,4 +124,10 @@ enum Shaft {
   STIFF
   MEDIUM
   FLEXIBLE
+}
+
+enum ClubRole {
+  OWNER
+  MANAGER
+  MEMBER
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { EjsAdapter } from '@nestjs-modules/mailer/dist/adapters/ejs.adapter';
 import { AuthModule } from 'auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { StatisticsModule } from 'statistics/statistics.module';
+import { ClubsModule } from 'clubs/clubs.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { StatisticsModule } from 'statistics/statistics.module';
     }),
     AuthModule,
     StatisticsModule,
+    ClubsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -7,6 +7,8 @@ import { UsersRepository } from 'users/users.repository';
 import { LocalStrategy } from 'auth/strategies/local.strategy';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from 'auth/strategies/jwt.strategy';
+import { UserClubService } from 'user-clubs/user-club.service';
+import { UserClubRepository } from 'user-clubs/user-club.repository';
 
 @Module({
   imports: [
@@ -23,6 +25,8 @@ import { JwtStrategy } from 'auth/strategies/jwt.strategy';
     UsersRepository,
     LocalStrategy,
     JwtStrategy,
+    UserClubService,
+    UserClubRepository,
   ],
   controllers: [AuthController],
 })

--- a/backend/src/clubs/clubs.controller.ts
+++ b/backend/src/clubs/clubs.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('clubs')
+export class ClubsController {}

--- a/backend/src/clubs/clubs.controller.ts
+++ b/backend/src/clubs/clubs.controller.ts
@@ -1,4 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Param, ParseIntPipe, Post } from '@nestjs/common';
+import { ClubsService } from 'clubs/clubs.service';
 
 @Controller('clubs')
-export class ClubsController {}
+export class ClubsController {
+  constructor(private readonly clubsService: ClubsService) {}
+
+  @Post('/:userId')
+  async createClub(
+    @Param('userId', ParseIntPipe) userId: number,
+    @Body('clubName') clubName: string,
+  ) {
+    await this.clubsService.createClub(userId, clubName);
+  }
+}

--- a/backend/src/clubs/clubs.controller.ts
+++ b/backend/src/clubs/clubs.controller.ts
@@ -1,15 +1,25 @@
-import { Body, Controller, Param, ParseIntPipe, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'auth/guards/jwt-auth.guard';
+import { ClubsGuard } from 'clubs/clubs.guard';
 import { ClubsService } from 'clubs/clubs.service';
 
 @Controller('clubs')
 export class ClubsController {
   constructor(private readonly clubsService: ClubsService) {}
 
+  @UseGuards(JwtAuthGuard, ClubsGuard)
   @Post('/:userId')
   async createClub(
     @Param('userId', ParseIntPipe) userId: number,
     @Body('clubName') clubName: string,
   ) {
-    await this.clubsService.createClub(userId, clubName);
+    return await this.clubsService.createClub(userId, clubName);
   }
 }

--- a/backend/src/clubs/clubs.guard.ts
+++ b/backend/src/clubs/clubs.guard.ts
@@ -1,0 +1,19 @@
+import {
+  CanActivate,
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+
+@Injectable()
+export class ClubsGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const { params, user } = context.switchToHttp().getRequest();
+
+    if (Number(params.userId) !== user.userId) {
+      throw new UnauthorizedException('올바른 요청이 아닙니다.');
+    }
+
+    return true;
+  }
+}

--- a/backend/src/clubs/clubs.module.ts
+++ b/backend/src/clubs/clubs.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ClubsController } from 'clubs/clubs.controller';
+import { ClubsService } from 'clubs/clubs.service';
+
+@Module({
+  controllers: [ClubsController],
+  providers: [ClubsService],
+})
+export class ClubsModule {}

--- a/backend/src/clubs/clubs.module.ts
+++ b/backend/src/clubs/clubs.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ClubsController } from 'clubs/clubs.controller';
 import { ClubsService } from 'clubs/clubs.service';
+import { ClubsRepository } from 'clubs/clubs.repository';
 
 @Module({
   controllers: [ClubsController],
-  providers: [ClubsService],
+  providers: [ClubsService, ClubsRepository],
 })
 export class ClubsModule {}

--- a/backend/src/clubs/clubs.repository.ts
+++ b/backend/src/clubs/clubs.repository.ts
@@ -1,4 +1,21 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
 
 @Injectable()
-export class ClubsRepository {}
+export class ClubsRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  createClub(userId: number, clubName: string) {
+    return this.prismaService.club.create({
+      data: {
+        name: clubName,
+        UserClub: {
+          create: {
+            userId,
+            role: 'OWNER',
+          },
+        },
+      },
+    });
+  }
+}

--- a/backend/src/clubs/clubs.repository.ts
+++ b/backend/src/clubs/clubs.repository.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ClubsRepository {}

--- a/backend/src/clubs/clubs.service.ts
+++ b/backend/src/clubs/clubs.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ClubsService {}

--- a/backend/src/clubs/clubs.service.ts
+++ b/backend/src/clubs/clubs.service.ts
@@ -1,4 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import { ClubsRepository } from 'clubs/clubs.repository';
 
 @Injectable()
-export class ClubsService {}
+export class ClubsService {
+  constructor(private readonly clubRepository: ClubsRepository) {}
+
+  createClub(userId: number, clubName: string) {
+    return this.clubRepository.createClub(userId, clubName);
+  }
+}

--- a/backend/src/user-clubs/user-club.repository.ts
+++ b/backend/src/user-clubs/user-club.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ClubRole } from '@prisma/client';
 import { PrismaService } from 'prisma/prisma.service';
 
 @Injectable()
@@ -17,6 +18,16 @@ export class UserClubRepository {
     return this.prismaService.userClub.findMany({
       where: {
         clubId,
+      },
+    });
+  }
+
+  joinClub(userId: number, clubId: string, role: ClubRole) {
+    return this.prismaService.userClub.create({
+      data: {
+        userId,
+        clubId,
+        role,
       },
     });
   }

--- a/backend/src/user-clubs/user-club.repository.ts
+++ b/backend/src/user-clubs/user-club.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Injectable()
+export class UserClubRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  getUserClubs(userId: number) {
+    return this.prismaService.userClub.findMany({
+      where: {
+        userId,
+      },
+    });
+  }
+
+  getClubUsers(clubId: string) {
+    return this.prismaService.userClub.findMany({
+      where: {
+        clubId,
+      },
+    });
+  }
+}

--- a/backend/src/user-clubs/user-club.service.ts
+++ b/backend/src/user-clubs/user-club.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { UserClubRepository } from 'user-clubs/user-club.repository';
+
+@Injectable()
+export class UserClubService {
+  constructor(private readonly userClubRepository: UserClubRepository) {}
+
+  getUserClubs(userId: number) {
+    return this.userClubRepository.getUserClubs(userId);
+  }
+
+  getClubUsers(clubId: string) {
+    return this.userClubRepository.getClubUsers(clubId);
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { UsersService } from 'users/users.service';
 
 @Controller('users')
@@ -8,5 +8,10 @@ export class UsersController {
   @Get('/usable-nickname')
   async isUsableNickname(@Query('nickname') nickname: string) {
     return await this.usersService.isUsableNickname(nickname);
+  }
+
+  @Get('/:userId/clubs')
+  async getUserClubs(@Param('userId', ParseIntPipe) userId: number) {
+    return await this.usersService.getUserClubs(userId);
   }
 }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'auth/guards/jwt-auth.guard';
+import { ClubsGuard } from 'clubs/clubs.guard';
 import { UsersService } from 'users/users.service';
 
 @Controller('users')
@@ -10,6 +19,7 @@ export class UsersController {
     return await this.usersService.isUsableNickname(nickname);
   }
 
+  @UseGuards(JwtAuthGuard, ClubsGuard)
   @Get('/:userId/clubs')
   async getUserClubs(@Param('userId', ParseIntPipe) userId: number) {
     return await this.usersService.getUserClubs(userId);

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,9 +2,16 @@ import { Module } from '@nestjs/common';
 import { UsersService } from 'users/users.service';
 import { UsersController } from 'users/users.controller';
 import { UsersRepository } from 'users/users.repository';
+import { UserClubService } from 'user-clubs/user-club.service';
+import { UserClubRepository } from 'user-clubs/user-club.repository';
 
 @Module({
-  providers: [UsersService, UsersRepository],
+  providers: [
+    UsersService,
+    UsersRepository,
+    UserClubService,
+    UserClubRepository,
+  ],
   controllers: [UsersController],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, ConflictException } from '@nestjs/common';
 import { CreateUser } from '../auth/types/auth.interface';
 import { UsersRepository } from 'users/users.repository';
+import { UserClubService } from 'user-clubs/user-club.service';
 
 @Injectable()
 export class UsersService {
-  constructor(private readonly usersRepository: UsersRepository) {}
+  constructor(
+    private readonly usersRepository: UsersRepository,
+    private readonly userClubService: UserClubService,
+  ) {}
 
   async createUser(createUser: CreateUser) {
     const user = await this.getUser(createUser.email);
@@ -26,5 +30,9 @@ export class UsersService {
     }
 
     return true;
+  }
+
+  getUserClubs(userId: number) {
+    return this.userClubService.getUserClubs(userId);
   }
 }

--- a/backend/test/seed.ts
+++ b/backend/test/seed.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+const testAccount = {
+  id: 3000,
+  email: 'test@test.com',
+  password: bcrypt.hashSync('testPassword', 10),
+  nickname: 'testUser',
+  birthday: new Date(-1),
+  gender: 'MALE' as const,
+  rank: 'A' as const,
+};
+
+const main = async () => {
+  return await prisma.user.create({
+    data: {
+      ...testAccount,
+    },
+  });
+};
+
+main()
+  .catch((e) => console.error(e))
+  .finally(async () => await prisma.$disconnect());

--- a/backend/test/setup.ts
+++ b/backend/test/setup.ts
@@ -12,5 +12,11 @@ module.exports = async function () {
       ...process.env,
     },
   });
+
+  execSync('npx ts-node ./test/seed.ts', {
+    env: {
+      ...process.env,
+    },
+  });
   console.log('test db 생성 완료!');
 };


### PR DESCRIPTION
## 설명

- [x] 유저와 소모임 사이에 관계테이블(user_club)을 생성합니다.
- [x] 관계 테이블에는 유저의 Role( Onwer, Manager, Member) 도 같이 저장합니다.
- [x]  Create / Read api를 생성합니다.
  - [x] 유저가 속한 모임 조회 api 생성 (GET /users/:userId/clubs)
  - [x] 유저가 모임을 만드는 api 생성 (POST /clubs/:userId)
  - [x] 모임을 생성하면, 생성한 사람의 권한은 onwer입니다.
    - 로그인 되어있는 유저와, 모임을 생성하고자 하는 사람은 같아야합니다. 아닌 경우 적절한 에러 처리가 필요합니다.
    - 해당 부분은 transaction으로 처리 해야할 것 같아서 [문서](https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide#nested-writes)를 참고하였습니다.
- ~~[ ] req.user에 모임 별 권한을 넣어줍니다. (로그인 로직 수정)~~

### E2E 테스트 시나리오 
- 로그인 하지 않은 유저가 모임을 조회하는 경우 (401)
- 자신이 아닌 다른 유저의 모임들을 조회하는 경우 (403)
- 모임을 생성하면, User의 권한이 `ONWER` 인지 확인 

## 관련 이슈

Fix #155 

## 변경사항

## 스크린샷
![image](https://github.com/inkyu0103/badminton-app/assets/48270642/905635c6-12ee-4b98-8ea9-9d262cc72a97)